### PR TITLE
Fix quick starter id for conteo modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -726,6 +726,13 @@ function renderQuickStarters(starters) {
         button.className = buttonClasses;
         button.textContent = starterObject.NombrePantalla;
         button.dataset.functionName = starterObject.NombreFuncion;
+
+        // Si el iniciador corresponde a "registrarConteo" asignamos un id
+        // específico para poder referenciarlo desde otros scripts.
+        if (starterObject.NombreFuncion === 'registrarConteo') {
+            button.id = 'abrirModalConteoBtn';
+        }
+
         quickStartersContainer.appendChild(button);
     });
 }


### PR DESCRIPTION
## Summary
- assign `id="abrirModalConteoBtn"` to the quick starter button when its function is `registrarConteo`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6865b2332154832daa784b869cf76318