### PR TITLE
Add confirmation modal markup and initialization

### DIFF
--- a/conteo-modal.html
+++ b/conteo-modal.html
@@ -54,7 +54,16 @@
     </footer>
 </div>
 
-<div id="confirmation-modal-container" class="fixed inset-0 bg-slate-900 bg-opacity-75 hidden justify-center items-center p-4"></div>
+<div id="confirmation-modal-container" class="fixed inset-0 bg-slate-900 bg-opacity-75 hidden justify-center items-center p-4">
+    <div class="bg-slate-800 p-6 rounded-lg shadow-xl text-center max-w-sm w-full">
+        <h3 id="confirmation-title" class="text-xl font-bold mb-4 text-white"></h3>
+        <div id="confirmation-body" class="text-slate-300 mb-6"></div>
+        <div class="flex justify-center gap-4">
+            <button id="confirm-btn-primary" class="px-4 py-2 text-white rounded-md bg-blue-600 hover:bg-blue-700"></button>
+            <button id="confirm-btn-secondary" class="px-4 py-2 text-white rounded-md bg-slate-600 hover:bg-slate-700">Cancelar</button>
+        </div>
+    </div>
+</div>
 
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -826,6 +826,18 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Función que se ejecuta una vez que el HTML del modal está en la página
     function inicializarModal() {
+        const confirmContainer = document.getElementById('confirmation-modal-container');
+        if (confirmContainer && !document.getElementById('confirmation-title')) {
+            confirmContainer.innerHTML = `
+                <div class="bg-slate-800 p-6 rounded-lg shadow-xl text-center max-w-sm w-full">
+                    <h3 id="confirmation-title" class="text-xl font-bold mb-4 text-white"></h3>
+                    <div id="confirmation-body" class="text-slate-300 mb-6"></div>
+                    <div class="flex justify-center gap-4">
+                        <button id="confirm-btn-primary" class="px-4 py-2 text-white rounded-md bg-blue-600 hover:bg-blue-700"></button>
+                        <button id="confirm-btn-secondary" class="px-4 py-2 text-white rounded-md bg-slate-600 hover:bg-slate-700">Cancelar</button>
+                    </div>
+                </div>`;
+        }
         // Listeners para botones principales
         document.getElementById('close-modal-button').addEventListener('click', cerrarModalDeConteo);
         document.getElementById('register-counts-button').addEventListener('click', registrarConteos);


### PR DESCRIPTION
## Summary
- add confirmation modal inner elements
- ensure modal HTML exists on modal initialization

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865bae808c0832d9d804007526d8a8b