### PR TITLE
Fix inventory modal colors and count logging

### DIFF
--- a/Toolbox.gs
+++ b/Toolbox.gs
@@ -184,8 +184,8 @@ function generarResumenAdmin() {
  */
 function registrarMultiplesConteos(conteos, userId) {
   try {
-const userProfile = obtenerDetallesDeUsuario(userId);
-const userName = userProfile ? userProfile.Nombre : 'Desconocido';
+    const userProfile = obtenerDetallesDeUsuario(userId);
+    const userName = userProfile ? userProfile.Nombre : 'Desconocido';
     const userSucursal = userProfile ? userProfile.Sucursal : 'Desconocida';
 
     conteos.forEach(conteo => {
@@ -193,17 +193,26 @@ const userName = userProfile ? userProfile.Nombre : 'Desconocido';
 
       const conteoId = `CONTEO-${new Date().getTime()}-${Math.floor(Math.random() * 1000)}`;
 
+      const diferencia =
+        (parseFloat(conteo.stockFisico) || 0) -
+        (parseFloat(conteo.stockSistema) || 0) -
+        (parseFloat(conteo.vpe) || 0) -
+        (parseFloat(conteo.cpi) || 0);
+
       appendRowToSheet(SHEET_NAMES.CONTEOS, {
         ID_Conteo: conteoId,
-        Fecha: nowFormatted.split(' ')[0], // Extrae solo la fecha
-        Hora: nowFormatted.split(' ')[1],  // Extrae solo la hora
+        Fecha: nowFormatted.split(' ')[0],
+        Hora: nowFormatted.split(' ')[1],
         UsuarioID: userId,
         NombreUsuario: userName,
-        ClaveProducto: conteo.clave,
-        DescripcionProducto: conteo.producto,
-        CantidadSistema: conteo.sistema,
-        CantidadFisico: conteo.fisico,
-        Diferencia: conteo.fisico - conteo.sistema,
+        ClaveProducto: "'" + String(conteo.clave),
+        DescripcionProducto: conteo.descripcion,
+        CantidadSistema: conteo.stockSistema,
+        CantidadFisico: conteo.stockFisico,
+        CPI: conteo.cpi,
+        VPE: conteo.vpe,
+        'Razón de Ajuste': conteo.razon,
+        Diferencia: diferencia,
         Observacion: conteo.observacion || '',
         SucursalUsuario: userSucursal
       });

--- a/conteo-modal.html
+++ b/conteo-modal.html
@@ -8,7 +8,7 @@
 
 <div id="conteo-modal" class="w-full max-w-6xl h-[80vh] bg-white rounded-2xl shadow-2xl flex flex-col">
     <header class="flex justify-between items-center p-6 border-b border-gray-200">
-        <h2 class="text-2xl font-bold">Registro de Conteo</h2>
+        <h2 class="text-2xl font-bold text-gray-900">Registro de Conteo</h2>
         <button id="close-modal-button" type="button" class="bg-red-600 hover:bg-red-700 px-4 py-2 rounded-lg">Cerrar</button>
     </header>
 
@@ -24,15 +24,15 @@
         <table class="w-full text-left">
             <thead class="sticky top-0 bg-gray-200 z-10">
                 <tr>
-                    <th class="p-3 text-center w-4"><input type="checkbox" id="select-all-checkbox"></th>
-                    <th class="p-3">Producto</th>
-                    <th class="p-3 w-32">Sistema</th>
-                    <th class="p-3 w-32">Físico</th>
-                    <th class="p-3 w-24">CPI</th>
-                    <th class="p-3 w-24">VPE</th>
-                    <th class="p-3 w-48">Razón</th>
-                    <th class="p-3 w-24">Diferencia</th>
-                    <th class="p-3 w-16">Acciones</th>
+                    <th class="p-3 text-center w-4 font-semibold text-gray-700"><input type="checkbox" id="select-all-checkbox"></th>
+                    <th class="p-3 font-semibold text-gray-700">Producto</th>
+                    <th class="p-3 w-32 font-semibold text-gray-700">Sistema</th>
+                    <th class="p-3 w-32 font-semibold text-gray-700">Físico</th>
+                    <th class="p-3 w-24 font-semibold text-gray-700">CPI</th>
+                    <th class="p-3 w-24 font-semibold text-gray-700">VPE</th>
+                    <th class="p-3 w-48 font-semibold text-gray-700">Razón</th>
+                    <th class="p-3 w-24 font-semibold text-gray-700">Diferencia</th>
+                    <th class="p-3 w-16 font-semibold text-gray-700">Acciones</th>
                 </tr>
             </thead>
             <tbody id="inventory-table-body">

--- a/index.html
+++ b/index.html
@@ -79,6 +79,9 @@
         .row-diff-negative { background-color: #fef2f2; }
         .row-diff-positive:hover { background-color: #dcfce7; }
         .row-diff-negative:hover { background-color: #fee2e2; }
+        .diff-positive { color: #15803d; }
+        .diff-negative { color: #b91c1c; }
+        .diff-zero { color: #475569; }
 
 /* ... otras reglas ... */
 
@@ -916,7 +919,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     <div class="text-sm font-medium text-gray-900">${item.Descripcion || 'N/A'}</div>
                     <div class="text-xs text-gray-500">${item.Clave}</div>
                 </td>
-                <td class="px-2 py-3 text-center"><input type="number" readonly value="${item.StockSistema || 0}" class="w-24 p-2 text-center bg-gray-100 border border-gray-300 rounded-md"></td>
+                <td class="px-2 py-3 text-center"><input type="number" data-type="stockSistema" value="${item.StockSistema || 0}" class="w-24 p-2 text-center bg-gray-100 border border-gray-300 rounded-md text-gray-900"></td>
                 <td class="px-2 py-3 text-center"><input type="number" data-type="stockFisico" value="${stockFisico}" placeholder="0" class="w-24 p-2 text-center border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-indigo-500"></td>
                 <td class="px-2 py-3 text-center"><input type="number" data-type="cpi" value="${cpi}" placeholder="0" class="w-24 p-2 text-center border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-indigo-500"></td>
                 <td class="px-2 py-3 text-center"><input type="number" data-type="vpe" value="${vpe}" placeholder="0" class="w-24 p-2 text-center border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-indigo-500"></td>
@@ -954,7 +957,7 @@ document.addEventListener('DOMContentLoaded', () => {
              editedData[clave] = {
                 clave: clave,
                 descripcion: row.querySelector('.text-sm.font-medium').textContent,
-                stockSistema: parseFloat(row.querySelector('input[readonly]').value) || 0,
+                stockSistema: parseFloat(row.querySelector('input[data-type="stockSistema"]').value) || 0,
                 stockFisico: stockFisicoInput.value,
                 cpi: row.querySelector('input[data-type="cpi"]').value,
                 vpe: row.querySelector('input[data-type="vpe"]').value,
@@ -965,7 +968,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     
     function calcularYMostrarDiferencia(row) {
-        const sistema = parseFloat(row.querySelector('input[readonly]').value) || 0;
+        const sistema = parseFloat(row.querySelector('input[data-type="stockSistema"]').value) || 0;
         const fisico = parseFloat(row.querySelector('input[data-type="stockFisico"]').value) || 0;
         const cpi = parseFloat(row.querySelector('input[data-type="cpi"]').value) || 0;
         const vpe = parseFloat(row.querySelector('input[data-type="vpe"]').value) || 0;


### PR DESCRIPTION
## Summary
- improve text contrast and row difference colors in inventory count modal
- allow editing system count in the modal and store extra count data
- correct logging of inventory counts with CPI, VPE and reason fields

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865ee013e98832db5c67f5cd362717d