### PR TITLE
Actualizar manejo de MovimientosPendientes

### DIFF
--- a/AdminPanel.gs
+++ b/AdminPanel.gs
@@ -115,15 +115,16 @@ function obtenerMovimientosDeCaja() {
 
     Logger.log('Paso 2: Mapeando y estandarizando ítems de Caja...');
     const itemsCaja = movimientosCaja.map(m => {
-      const fechaObj = parseSafeDate(m.FechaHoraSolicitud); // Asumo que la columna de fecha en MovimientosPendientes se llama FechaHoraSolicitud
+      const fechaObj = parseSafeDate(`${m.FechaSolicitud} ${m.HoraSolicitud}`);
       const item = {
         id: m.ID_Movimiento,
-        tipo: 'Caja', // Tipo fijo
-        fecha: fechaObj ? fechaObj.toISOString() : null, // Convertir a ISO String para envío al frontend
+        tipo: 'Caja',
+        fecha: fechaObj ? fechaObj.toISOString() : null,
         usuario: m.UsuarioSolicitanteID,
         asunto: m.Concepto,
         detalle: `Tipo: ${m.Tipo} - Monto: $${m.Monto}`,
-        estado: m.Estado
+        estado: m.Estado,
+        sucursal: m.Sucursal
       };
       return item;
     });

--- a/Toolbox.gs
+++ b/Toolbox.gs
@@ -125,16 +125,25 @@ function registrarMovimientoCaja(tipo, monto, concepto, userId) {
   try {
     const spreadsheet = SpreadsheetApp.openById(ID_HOJA_PUENTE);
     const sheet = spreadsheet.getSheetByName(SHEET_NAMES.MOVIMIENTOS_PENDIENTES);
-    const movimientoId = `MOV-${new Date().getTime()}-${Math.floor(Math.random() * 1000)}`;
+    const movimientoId = `MOV-${Date.now()}`; // ID simplificado
+
+    const userProfile = obtenerDetallesDeUsuario(userId);
+    const sucursal = userProfile ? userProfile.Sucursal : '';
+
+    const nowFormatted = getFormattedTimestamp();
+    const fecha = nowFormatted.split(' ')[0];
+    const hora = nowFormatted.split(' ')[1];
 
     sheet.appendRow([
       movimientoId, // ID_Movimiento
-      getFormattedTimestamp(), // FechaHoraSolicitud
+      fecha, // FechaSolicitud
+      hora, // HoraSolicitud
       userId, // UsuarioSolicitanteID
       tipo, // Tipo (será 'Ingreso' o 'Egreso')
       monto, // Monto
       concepto, // Concepto
       'Pendiente', // Estado
+      sucursal, // Sucursal del usuario solicitante
       '', // FechaAprobacion (vacío)
       ''  // UsuarioAprobadorID (vacío)
     ]);


### PR DESCRIPTION
## Summary
- registrarMovimientoCaja ahora genera IDs simplificados y guarda fecha y hora por separado
- se añade la sucursal del usuario en cada movimiento
- obtenerMovimientosDeCaja ajustado para leer las nuevas columnas de fecha, hora y sucursal

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6868437df858832dab8ea9614ed60202