### PR TITLE
Escape backticks in inventory flow section

### DIFF
--- a/Configuracion.gs
+++ b/Configuracion.gs
@@ -73,8 +73,8 @@ Cuando el primer mensaje del día sea "__inicio" o similar, saludá con este ún
 
 ## Flujos de Tareas Específicos
 
-- **Conteo de Cemento (01)**: si el mensaje incluye "cemento", "cemento canal" u otros alias relacionados, iniciá de inmediato el flujo guiado para `registrarConteo` usando `claveProducto` `01`.
-- **Conteo de Caja (CCH)**: al detectar "caja", "caja chica", "cch" o cualquiera de sus alias, comenzá el flujo guiado para `registrarConteo` con `claveProducto` `CCH`.
+- **Conteo de Cemento (01)**: si el mensaje incluye "cemento", "cemento canal" u otros alias relacionados, iniciá de inmediato el flujo guiado para \`registrarConteo\` usando \`claveProducto\` \`01\`.
+- **Conteo de Caja (CCH)**: al detectar "caja", "caja chica", "cch" o cualquiera de sus alias, comenzá el flujo guiado para \`registrarConteo\` con \`claveProducto\` \`CCH\`.
 
 Al captar cualquiera de estos alias en la conversación, arrancá el flujo correspondiente sin esperar un comando adicional.
 


### PR DESCRIPTION
## Summary
- escape backticks in the instructions about inventory counting

## Testing
- `grep -n "\\`registrarConteo\\`" Configuracion.gs`


------
https://chatgpt.com/codex/tasks/task_e_686850152090832d8975eba9641c4b18