### PR TITLE
Añade función ultimaFecha

### DIFF
--- a/Toolbox.gs
+++ b/Toolbox.gs
@@ -347,3 +347,39 @@ function enviarMensajeAdministrador(destinoSesion, destinoUsuarioId, contenido, 
     throw new Error(`Error al enviar mensaje: ${e.message}`);
   }
 }
+
+/**
+ * Devuelve la fecha más reciente de la hoja 'Conteos'.
+ * @returns {string} Fecha en formato 'yyyy-MM-dd' o cadena vacía.
+ */
+function ultimaFecha() {
+  try {
+    const registros = getSheetData(SHEET_NAMES.CONTEOS);
+    if (!registros || registros.length === 0) {
+      return '';
+    }
+
+    const tz = SpreadsheetApp.getActiveSpreadsheet().getSpreadsheetTimeZone();
+    let fechaMax = null;
+
+    registros.forEach(r => {
+      const texto = r.Fecha;
+      let fecha = parseSafeDate(texto);
+      if (!fecha) {
+        try {
+          fecha = Utilities.parseDate(texto, tz, 'dd/MM/yyyy');
+        } catch (e) {
+          fecha = null;
+        }
+      }
+      if (fecha && (!fechaMax || fecha.getTime() > fechaMax.getTime())) {
+        fechaMax = fecha;
+      }
+    });
+
+    return fechaMax ? Utilities.formatDate(fechaMax, tz, 'yyyy-MM-dd') : '';
+  } catch (e) {
+    logError('Toolbox', 'ultimaFecha', e.message, e.stack);
+    return '';
+  }
+}


### PR DESCRIPTION
## Resumen
- se implementa `ultimaFecha` en Toolbox.gs para obtener la fecha más reciente de la hoja Conteos
- se analiza cada registro con `parseSafeDate` y `Utilities.parseDate`
- si no hay datos la función devuelve cadena vacía

## Pruebas
- `echo "Sin pruebas automáticas"`

------
https://chatgpt.com/codex/tasks/task_e_686871ca1874832dace632cf1f84a7ff