### PR TITLE
Añade campo contacto en herramientas de caja

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -302,11 +302,11 @@ function ejecutarHerramienta(functionName, functionArgs, userId, sessionId) {
 
       case 'registrarIngresoCaja':
         Logger.log('   - Entrando en el caso: "registrarIngresoCaja"');
-        return registrarMovimientoCaja('Ingreso', functionArgs.monto, functionArgs.concepto, userId);
+        return registrarMovimientoCaja('Ingreso', functionArgs.monto, functionArgs.concepto, functionArgs.contacto, userId);
 
       case 'registrarEgresoCaja':
         Logger.log('   - Entrando en el caso: "registrarEgresoCaja"');
-        return registrarMovimientoCaja('Egreso', functionArgs.monto, functionArgs.concepto, userId);
+        return registrarMovimientoCaja('Egreso', functionArgs.monto, functionArgs.concepto, functionArgs.contacto, userId);
 
       case 'registrarConteo':
         Logger.log('   - Entrando en el caso: "registrarConteo"');

--- a/Configuracion.gs
+++ b/Configuracion.gs
@@ -331,7 +331,11 @@ const HERRAMIENTAS_AI = [
         concepto: {
           type: 'string',
           description: "La razón o descripción breve del ingreso. Ej: 'Abono cliente Construcciones S.A.', 'Venta de contado tornillos'."
-        }
+        },
+      contacto: {
+        type: 'string',
+        description: 'Nombre de quien entrega o recibe el dinero.'
+      },
       },
       required: ['monto', 'concepto', 'contacto']
     },
@@ -358,7 +362,11 @@ const HERRAMIENTAS_AI = [
         concepto: {
           type: 'string',
           description: "La razón o descripción breve del gasto. Ej: 'Compra de papelería para oficina', 'Pago de almuerzo personal'."
-        }
+        },
+      contacto: {
+        type: 'string',
+        description: 'Nombre de quien entrega o recibe el dinero.'
+      },
       },
       required: ['monto', 'concepto', 'contacto']
     },

--- a/Test.gs
+++ b/Test.gs
@@ -111,7 +111,7 @@ function testLoginAndChatLogic() {
   // Prueba de registrarMovimientoCaja
   try {
     Logger.log('   - Probando: registrarMovimientoCaja() (ejecución directa).');
-    const resultadoMovimiento = registrarMovimientoCaja('Ingreso', 100.50, 'Ingreso de prueba desde test suite', TEST_NORMAL_USER_ID);
+    const resultadoMovimiento = registrarMovimientoCaja('Ingreso', 100.50, 'Ingreso de prueba desde test suite', 'Cliente Test', TEST_NORMAL_USER_ID);
     Logger.log(`     ✅ Éxito. Respuesta: "${resultadoMovimiento}"`);
   } catch (e) {
     Logger.log(`     ❌ ERROR en registrarMovimientoCaja: ${e.message}`);

--- a/Toolbox.gs
+++ b/Toolbox.gs
@@ -118,10 +118,11 @@ const userName = userProfile ? userProfile.Nombre : 'Desconocido';
  * @param {string} tipo - El tipo de movimiento ('Ingreso' o 'Egreso').
  * @param {number} monto - La cantidad del dinero.
  * @param {string} concepto - La razón o descripción del movimiento.
+ * @param {string} contacto - Persona o entidad relacionada con el movimiento.
  * @param {string} userId - ID del usuario que solicita el movimiento.
  * @returns {string} Mensaje de confirmación.
  */
-function registrarMovimientoCaja(tipo, monto, concepto, userId) {
+function registrarMovimientoCaja(tipo, monto, concepto, contacto, userId) {
   try {
     const spreadsheet = SpreadsheetApp.openById(ID_HOJA_PUENTE);
     const sheet = spreadsheet.getSheetByName(SHEET_NAMES.MOVIMIENTOS_PENDIENTES);
@@ -142,16 +143,17 @@ function registrarMovimientoCaja(tipo, monto, concepto, userId) {
       tipo, // Tipo (será 'Ingreso' o 'Egreso')
       monto, // Monto
       concepto, // Concepto
+      contacto, // Contacto
       'Pendiente', // Estado
       sucursal, // Sucursal del usuario solicitante
       '', // FechaAprobacion (vacío)
       ''  // UsuarioAprobadorID (vacío)
     ]);
 
-    return `¡Solicitud registrada! Un supervisor debe aprobar el ${tipo.toLowerCase()} de $${monto} por "${concepto}".`;
+    return `¡Solicitud registrada! Un supervisor debe aprobar el ${tipo.toLowerCase()} de $${monto} para ${contacto} por "${concepto}".`;
 
   } catch (e) {
-    logError('Toolbox', 'registrarMovimientoCaja', e.message, e.stack, JSON.stringify({ tipo, monto, concepto, userId }));
+    logError('Toolbox', 'registrarMovimientoCaja', e.message, e.stack, JSON.stringify({ tipo, monto, concepto, contacto, userId }));
     throw new Error(`Error al registrar la solicitud de movimiento: ${e.message}`);
   }
 }


### PR DESCRIPTION
## Resumen
- se define `contacto` en las herramientas de ingreso y egreso de caja
- `registrarMovimientoCaja` ahora recibe y almacena este dato
- se actualizan las llamadas en `Code.gs` y las pruebas

## Pruebas
- `echo "Sin pruebas automáticas"`

------
https://chatgpt.com/codex/tasks/task_e_6868db7bc684832dbf81d1048d0e5f28