### PR TITLE
Corrección menor en creación de sesiones

### DIFF
--- a/Controladores.gs
+++ b/Controladores.gs
@@ -45,7 +45,7 @@ function cargarDatosIniciales(userId, pin) {
     const rolUsuario = perfil.Rol;
     const sessionId = 'SESS-' + Date.now() + '-' + Utilities.getUuid().substring(0, 8);
 
-    appendRowToSheet('SesionesChat', {
+    appendRowToSheet(SHEET_NAMES.SESIONES, {
       SesionID: sessionId,
       UsuarioID: perfil.UsuarioID,
       FechaInicio: getFormattedTimestamp(),


### PR DESCRIPTION
## Resumen
- se utiliza la constante `SHEET_NAMES.SESIONES` al registrar una nueva sesión

## Pruebas
- `echo "Sin pruebas automáticas"`


------
https://chatgpt.com/codex/tasks/task_e_6868de27408c832d837fc5d612104193