### PR TITLE
Implementar recorte de historial

### DIFF
--- a/Configuracion.gs
+++ b/Configuracion.gs
@@ -13,6 +13,7 @@ const EMBEDDING_MODEL = 'text-embedding-3-small';
 
 const OPENAI_API_URL = "https://api.openai.com/v1/chat/completions";
 const ID_HOJA_PUENTE = '1nj2UfUPK5xQg6QI68j9ArLss-ptrlaN3PY8NMOr_Jhg';
+const MAX_MENSAJES_HISTORIAL = 40;
 
 // ===============================================================
 // ==== CENTRALIZACIÓN DE NOMBRES DE HOJAS ====

--- a/Toolbox.gs
+++ b/Toolbox.gs
@@ -173,10 +173,12 @@ function generarResumenAdmin() {
       return f && Utilities.formatDate(f, tz, 'yyyy-MM-dd') === today;
     });
 
-    const mensajes = getSheetData(SHEET_NAMES.MENSAJES).filter(m => {
+    let mensajes = getSheetData(SHEET_NAMES.MENSAJES).filter(m => {
       const f = parseSafeDate(m.FechaHora);
       return f && Utilities.formatDate(f, tz, 'yyyy-MM-dd') === today;
     });
+
+    mensajes = limitarHistorial(mensajes, MAX_MENSAJES_HISTORIAL, 'Toolbox');
 
     let listadoMensajes = '';
     mensajes.forEach(m => {
@@ -496,6 +498,8 @@ function resumenChatUsuario(userId) {
         }
       }
     });
+
+    conversationMessages = limitarHistorial(conversationMessages, MAX_MENSAJES_HISTORIAL, 'Toolbox', userId);
 
     if (conversationMessages.length === 0) {
       return 'No se encontró historial para resumir.';


### PR DESCRIPTION
## Resumen
- agregar constante `MAX_MENSAJES_HISTORIAL`
- crear función `limitarHistorial`
- usarla en `enviarAOpenAI`, `generarResumenAdmin` y `resumenChatUsuario`
- registrar advertencia cuando se recorta

## Pruebas
- `echo "Sin pruebas automáticas"`

------
https://chatgpt.com/codex/tasks/task_e_686d8476b438832daa63de2703d63125