### PR TITLE
Actualiza README con manejo de error 429

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,7 @@ La hoja `MemoriaVectorial` se utiliza para almacenar los embeddings de conversac
 2. Selecciona la función `testSuiteBackend` en el menú desplegable de la barra de herramientas y ejecútala.
 3. Revisa la salida en el registro de ejecuciones para verificar los resultados de cada prueba.
 
+## Errores comunes
+
+- **HTTP 429** – Generalmente indica que se alcanzó un límite de cuota o de tasa. El sistema realiza varios reintentos automáticos. Si el problema persiste, revisá la configuración de la clave y la cuota disponible en OpenAI.
+


### PR DESCRIPTION
## Resumen
- agrega sección de errores comunes en README
- explica que el HTTP 429 suele deberse a límites de cuota o de tasa
- aclara que el sistema reintenta las solicitudes y sugiere revisar la configuración de la clave y la cuota

## Pruebas
- `echo "Sin pruebas automáticas"`

------
https://chatgpt.com/codex/tasks/task_e_686df0304ad4832db38e269d9dd4a17f