### PR TITLE
Implementa límites de tokens en historial y resúmenes

### DIFF
--- a/Configuracion.gs
+++ b/Configuracion.gs
@@ -9,6 +9,8 @@ const MODELO_DEFAULT = 'gpt-4o-mini';
 const TEMPERATURA_AI = 0.7;
 const MAX_TOKENS_AI = 1500; // Aumentado ligeramente para dar más espacio a las respuestas
 const EMBEDDING_MODEL = 'text-embedding-3-small';
+const MAX_TOKENS_HISTORIAL = 3000; // Límite aproximado para el historial enviado a la IA
+const MAX_MENSAJES_HISTORIAL = 40;  // Cantidad máxima de mensajes en el historial
 
 
 const OPENAI_API_URL = "https://api.openai.com/v1/chat/completions";

--- a/Toolbox.gs
+++ b/Toolbox.gs
@@ -191,6 +191,8 @@ function generarResumenAdmin() {
       listadoMensajes += linea + '\n';
     });
 
+    listadoMensajes = limitarTexto(listadoMensajes);
+
     const resumenDatos =
       `Conteos realizados: ${conteos.length}\n` +
       `Problemas pendientes: ${mensajes.filter(m => m.TipoMensaje === 'Problema' && m.Estado === 'Pendiente').length}\n` +
@@ -488,6 +490,8 @@ function resumenChatUsuario(userId) {
         }
       }
     });
+
+    conversationMessages = limitarHistorial([{ role: 'system', content: '' }, ...conversationMessages]).slice(1);
 
     if (conversationMessages.length === 0) {
       return 'No se encontró historial para resumir.';


### PR DESCRIPTION
## Resumen
- añade constantes `MAX_TOKENS_HISTORIAL` y `MAX_MENSAJES_HISTORIAL`
- crea funciones `contarTokens`, `limitarHistorial` y `limitarTexto`
- utiliza estas funciones en `enviarAOpenAI`, `generarResumenAdmin` y `resumenChatUsuario`
- registra un mensaje de error cuando se recorta información

## Pruebas
- `echo "Sin pruebas automáticas"`

------
https://chatgpt.com/codex/tasks/task_e_686df149df0c832d8aad28ab2ea2a529