### PR TITLE
Implementar control de tokens en embeddings

### DIFF
--- a/Configuracion.gs
+++ b/Configuracion.gs
@@ -9,6 +9,7 @@ const MODELO_DEFAULT = 'gpt-4o-mini';
 const TEMPERATURA_AI = 0.7;
 const MAX_TOKENS_AI = 1500; // Aumentado ligeramente para dar más espacio a las respuestas
 const EMBEDDING_MODEL = 'text-embedding-3-small';
+const MAX_TOKENS_EMBEDDING = 8191; // Límite oficial del modelo de embedding
 const MAX_TOKENS_HISTORIAL = 3000; // Límite aproximado para el historial enviado a la IA
 const MAX_MENSAJES_HISTORIAL = 40;  // Cantidad máxima de mensajes en el historial
 

--- a/Memoria.gs
+++ b/Memoria.gs
@@ -4,6 +4,12 @@
 
 function generarEmbedding(texto) {
   try {
+    // El modelo admite hasta MAX_TOKENS_EMBEDDING tokens
+    const totalTokens = contarTokens(texto);
+    if (totalTokens > MAX_TOKENS_EMBEDDING) {
+      logError('Memoria', 'generarEmbedding', `Texto supera el límite de ${MAX_TOKENS_EMBEDDING} tokens`);
+      texto = limitarTexto(texto, MAX_TOKENS_EMBEDDING);
+    }
     const url = 'https://api.openai.com/v1/embeddings';
     const payload = {
       model: EMBEDDING_MODEL,


### PR DESCRIPTION
## Resumen
- definir `MAX_TOKENS_EMBEDDING` en `Configuracion.gs`
- cortar el texto en `generarEmbedding` si se excede el límite y registrar el intento

## Pruebas
- `echo "Sin pruebas automáticas"`

------
https://chatgpt.com/codex/tasks/task_e_686df2eee70c832daf5808ddec70fed0