### PR TITLE
Ajuste de manejo de errores en enviarAOpenAI

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -236,9 +236,16 @@ function enviarAOpenAI(sessionId, userId, payload) {
         return { content: 'Demasiadas solicitudes a la API. Intentá nuevamente en unos minutos.' };
     }
 
-    if (responseCode !== 200) {
+    if (responseCode !== 200 && responseCode !== 429) {
         logError('Code', 'enviarAOpenAI', `API call failed (${responseCode}): ${responseText}`, null, JSON.stringify(requestPayload), userId);
-        throw new Error(`El asistente no pudo responder (Error ${responseCode}).`);
+        let detalle = '';
+        try {
+          const errorObj = JSON.parse(responseText);
+          if (errorObj.error && errorObj.error.message) {
+            detalle = ` Detalle: ${errorObj.error.message}`;
+          }
+        } catch (e) {}
+        throw new Error(`El asistente no pudo responder (Error ${responseCode}).${detalle}`);
     }
 
     const responseJson = JSON.parse(responseText);


### PR DESCRIPTION
## Resumen
- cuando la respuesta de OpenAI no sea 200 ni 429 se analiza el mensaje de error
- se incluye el detalle de la API en la excepción devuelta al usuario
- se mantiene el registro en `logError`

## Pruebas
- `echo "Sin pruebas automáticas"`

------
https://chatgpt.com/codex/tasks/task_e_686f0ee9f83c832db5c325d5fc6a4e35