### PR TITLE
Actualizar recorte de texto

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -139,7 +139,7 @@ function limitarTexto(texto, limiteTokens = MAX_TOKENS_HISTORIAL) {
   if (totalTokens <= limiteTokens) return texto;
   logError('Code', 'limitarTexto', 'Texto recortado por exceso de tokens');
   const maxChars = limiteTokens * 4;
-  return texto.slice(texto.length - maxChars);
+  return texto.slice(0, maxChars);
 }
 
 function obtenerHistorialReciente(userId, sesionActual) {


### PR DESCRIPTION
## Resumen
- mantener el inicio del texto al llamar `limitarTexto`

## Pruebas
- `echo "Sin pruebas automáticas"`

------
https://chatgpt.com/codex/tasks/task_e_686f3694b870832daf89c446074f0332