### PR TITLE
Actualiza resumen diario con encabezado y días sin reportes

### DIFF
--- a/index.html
+++ b/index.html
@@ -165,7 +165,7 @@
     <div id="custom-alert-modal" class="fixed inset-0 bg-slate-900 bg-opacity-75 hidden justify-center items-center p-4 z-[100]">
         <div class="bg-slate-800 p-6 rounded-lg shadow-xl text-center max-w-sm w-full">
             <h3 id="custom-alert-title" class="text-xl font-bold mb-4 text-white"></h3>
-            <p id="custom-alert-message" class="text-slate-300 mb-6"></p>
+            <p id="custom-alert-message" class="text-slate-300 mb-6 whitespace-pre-line"></p>
             <button id="custom-alert-close-btn" class="bg-blue-600 hover:bg-blue-700 text-white font-semibold px-4 py-2 rounded-lg">
                 Aceptar
             </button>
@@ -561,7 +561,7 @@ function procesarDatosIniciales(datos) {
                 <input type="date" id="admin-filter-fecha" class="w-full bg-slate-700 rounded-md px-3 py-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-yellow-400 mb-3">
                 <input type="number" id="admin-resumen-dias" min="1" max="7" value="1" class="w-full bg-slate-700 rounded-md px-3 py-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-yellow-400 mb-3" placeholder="Días a resumir">
                  <button onclick="google.script.run.withSuccessHandler(resumen => showCustomAlert(resumen, 'info')).withFailureHandler(error => showCustomAlert('Error al cargar resumen: ' + error.message, 'error')).generarResumenAdmin(parseInt(document.getElementById('admin-resumen-dias').value,10));" class="w-full bg-amber-500 hover:bg-amber-600 text-white font-semibold rounded-lg px-4 py-1.5 text-sm">
-                    Generar Resumen Diario
+                    Generar Resumen
                 </button>
             </div>
             <div id="admin-items-container" class="p-4 space-y-3"></div>


### PR DESCRIPTION
## Resumen
- mejora `resumenAdminPorFecha` para omitir la sección de conteos si no hay datos
- refactoriza `generarResumenAdmin` para incluir un encabezado con el rango de fechas y agrupar los días sin reportes
- ajusta el modal de alerta para respetar saltos de línea y cambia el texto del botón de resumen

## Pruebas
- `echo "Sin pruebas automáticas"`

------
https://chatgpt.com/codex/tasks/task_e_686f369d8d18832d8ccf6afaa7bb39c1