### PR TITLE
Aumentar tokens en resumen y ajustar temperatura

### DIFF
--- a/Configuracion.gs
+++ b/Configuracion.gs
@@ -6,7 +6,7 @@
 // En: Configuracion.gs
 const OPENAI_API_KEY = PropertiesService.getScriptProperties().getProperty('OPENAI_API_KEY');
 const MODELO_DEFAULT = 'gpt-4o-mini';
-const TEMPERATURA_AI = 0.7;
+const TEMPERATURA_AI = 0.5;
 const MAX_TOKENS_AI = 1500; // Aumentado ligeramente para dar más espacio a las respuestas
 const MAX_TOKENS_HISTORIAL = 3000; // Límite aproximado para el historial enviado a la IA
 const MAX_MENSAJES_HISTORIAL = 40;  // Cantidad máxima de mensajes en el historial

--- a/Toolbox.gs
+++ b/Toolbox.gs
@@ -216,12 +216,12 @@ function resumenAdminPorFecha(fechaRef) {
         { role: 'system', content: instrucciones }
       ],
       temperature: TEMPERATURA_AI,
-      max_tokens: 200
+      max_tokens: 400
     };
 
     const apiResult = llamarOpenAI(payload);
     if (apiResult.code !== 200) {
-      logError('Toolbox', 'resumenAdminPorFecha', `Error API ${apiResult.code}`, null);
+      logError('Toolbox', 'resumenAdminPorFecha', `Error API ${apiResult.code}`, null, JSON.stringify(payload));
       return 'Error al generar el resumen.';
     }
     const json = JSON.parse(apiResult.text);


### PR DESCRIPTION
## Resumen
- se incrementa a 400 el límite de `max_tokens` para el resumen diario
- se reduce la temperatura de la IA a 0.5
- se registran en el log los detalles del payload cuando la API falla

## Pruebas
- `echo "Sin pruebas automáticas"`


------
https://chatgpt.com/codex/tasks/task_e_686f36b6f358832da81fd3d4bac0d2f4