### PR TITLE
Manejo de registros sin tool_call

### DIFF
--- a/index.html
+++ b/index.html
@@ -391,6 +391,23 @@ document.addEventListener('DOMContentLoaded', () => {
             addMessage(data.content, 'ai');
         }
 
+        const registroRegex = /ya registr(?:e|é)/i;
+        if (!data.tool_call && data.content && registroRegex.test(data.content)) {
+            showCustomAlert('El registro no se completó. Por favor, repetí el proceso.', 'error');
+            google.script.run.logError(
+                'Frontend',
+                'handleAIResponse',
+                'Texto de registro sin tool_call',
+                '',
+                data.content,
+                perfilActual?.UsuarioID || 'N/A'
+            );
+            messageInput.disabled = false;
+            sendButton.disabled = false;
+            messageInput.focus();
+            return;
+        }
+
         if (data.tool_call) {
             const toolCall = data.tool_call;
             const functionName = toolCall.function.name;


### PR DESCRIPTION
## Resumen
Se añadió una verificación en `handleAIResponse` para detectar cuando el asistente responde con frases de registro pero no envía `tool_call`. En ese caso se informa al usuario que el registro no se completó, se registra el incidente con `logError` y se reactiva el formulario de entrada.

## Pruebas
- `echo "Sin pruebas automáticas"`

------
https://chatgpt.com/codex/tasks/task_e_68700ad1b8b4832dbdc20ffbc3a14de8