### PR TITLE
Actualiza modelo y límites de token

### DIFF
--- a/Configuracion.gs
+++ b/Configuracion.gs
@@ -5,10 +5,10 @@
 
 // En: Configuracion.gs
 const OPENAI_API_KEY = PropertiesService.getScriptProperties().getProperty('OPENAI_API_KEY');
-const MODELO_DEFAULT = 'gpt-4o-mini';
+const MODELO_DEFAULT = 'gpt-4.1-mini';
 const TEMPERATURA_AI = 0.5;
-const MAX_TOKENS_AI = 1500; // Aumentado ligeramente para dar más espacio a las respuestas
-const MAX_TOKENS_HISTORIAL = 3000; // Límite aproximado para el historial enviado a la IA
+const MAX_TOKENS_AI = 2000; // Aumentado para aprovechar el nuevo modelo
+const MAX_TOKENS_HISTORIAL = 6000; // Se amplía el historial permitido
 const MAX_MENSAJES_HISTORIAL = 40;  // Cantidad máxima de mensajes en el historial
 
 


### PR DESCRIPTION
## Resumen
- cambia el modelo por defecto a `gpt-4.1-mini`
- aumenta los límites de tokens para respuestas y para el historial

## Pruebas
- `echo "Sin pruebas automáticas"`


------
https://chatgpt.com/codex/tasks/task_e_68700b0cd2c0832db7a9b059e5a75cba