### PR TITLE
Agregar herramienta de arqueo de caja

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -467,6 +467,18 @@ function ejecutarHerramienta(functionName, functionArgs, userId, sessionId) {
           functionArgs.pagosTarjeta
         );
 
+      case 'arqueoCaja':
+        Logger.log('   - Entrando en el caso: "arqueoCaja"');
+        return registrarArqueoCaja(
+          userId,
+          functionArgs.saldoSistema,
+          functionArgs.contado,
+          functionArgs.transferencia,
+          functionArgs.tarjeta,
+          functionArgs.diferencia,
+          functionArgs.razonDiferencia
+        );
+
       case 'generarResumenAdmin':
          Logger.log('   - Entrando en el caso: "generarResumenAdmin".');
          return generarResumenAdmin(functionArgs.dias);

--- a/Configuracion.gs
+++ b/Configuracion.gs
@@ -31,7 +31,8 @@ const SHEET_NAMES = {
   MOVIMIENTOS_PENDIENTES: 'MovimientosPendientes',
   CONFIGURACION_AI: 'ConfiguracionAI',
   PROMPTS_AI: 'PromptsAI',
-  HERRAMIENTAS_AI: 'HerramientasAI'
+  HERRAMIENTAS_AI: 'HerramientasAI',
+  ARQUEO_CAJA: 'ArqueoCaja'
 };
 
 
@@ -350,6 +351,34 @@ const HERRAMIENTAS_AI = [
     ComportamientoAdicional: '', // Sin comportamiento adicional específico para esta.
     EsQuickStarter: true,
     PromptEspecifico: 'Has determinado que el usuario quiere registrar un gasto. Tu siguiente paso es pedirle el monto y el concepto del gasto. Sé directo y eficiente.',
+  rolesPermitidos: ['Administrador', 'Cajero', 'Todo en uno']
+
+  },
+
+  // ===============================================================
+  // ==== HERRAMIENTA: Arqueo de Caja ====
+  // ===============================================================
+  {
+    NombreFuncion: 'arqueoCaja',
+    NombrePantalla: '🧮 Arqueo de Caja',
+    Descripcion: 'Inicia un proceso guiado e interactivo para realizar un arqueo o corte de caja. Usa esta función cuando el usuario quiera cuadrar su caja. A diferencia de un registro simple, esta herramienta ayuda al usuario a calcular los totales, actuando como un asistente.',
+    SchemaParametros: {
+      type: 'object',
+      properties: {
+        saldoSistema: {
+          type: 'number',
+          description: "El monto total que la columna 'Calculado' del reporte 'Corte de Caja' indica que debería haber en caja."
+        },
+        confirmacionRegistros: {
+          type: 'boolean',
+          description: 'El usuario debe confirmar que todos los ingresos y retiros del día ya han sido registrados en el sistema. Debe ser \'true\' para proceder.'
+        }
+      },
+      required: ['saldoSistema', 'confirmacionRegistros']
+    },
+    ComportamientoAdicional: 'Esta función no registra el arqueo final. Su propósito es iniciar un modo de conversación especial y de varios turnos. Una vez activado, el bot seguirá el PromptEspecifico para guiar al usuario, calcular los totales y, al final del proceso, llamará a la función registrarConteo con los datos recopilados.',
+    EsQuickStarter: true,
+    PromptEspecifico: 'Una vez activado este flujo, tu misión es ser un asistente que ayuda al usuario a contar. No pidas totales, pide los detalles y tú haces las sumas. Haz una breve explicacion de cómo funciona el proceso. 1. Pide el Total de la columna Calculado en "Corte de Caja" de Sicar conocido como Saldo del Sistema, pregunta  si todos los ingresos y retiros hechos hasta el momento ya fueron registrados para garantizar un proceso sin errores 2. Iniciar Conteo de Efectivo: Ya tienes el saldo del sistema. Tu siguiente paso es decir: "Perfecto. Ahora vamos a contar el efectivo. No lo sumes, solo decime la cantidad de billetes que tenés (ej: 10 de 500, 20 de 100), y yo hago el cálculo por vos." 3. Calcular Efectivo: Cuando el usuario te dé los billetes, calcula el subtotal, anúncialo y luego pide las monedas. Suma todo y confirma el Total de Efectivo Contado. 4. Contar Otros Métodos: Continúa con la misma dinámica para Vales y Tarjetas, pidiendo los montos individuales y sumándolos por categoría. 5. Presentar Resumen Final: Muestra una comparación clara entre el Saldo del Sistema y el Total Contado (la suma de todo lo que ayudaste a contar). Anuncia el resultado final: si hay un faltante o un sobrante y de cuánto es. 6. Obtener Justificación y Registrar: Si hay una diferencia, pregunta por la razón. Una vez que tengas la justificación, confirma con el usuario y llama a la función registrarConteo con claveProducto: "CCH", cantidadSistema, cantidadFisico (el total que calculaste) y la observacion del usuario.',
     rolesPermitidos: ['Administrador', 'Cajero', 'Todo en uno']
 
   },

--- a/Toolbox.gs
+++ b/Toolbox.gs
@@ -423,10 +423,49 @@ function registrarConteo(userId, claveProducto, cantidadSistema, cantidadFisico,
 
     sumarPuntos(userId, 50);
 
-    return `Conteo registrado para el producto ${claveFinal}.`;
+  return `Conteo registrado para el producto ${claveFinal}.`;
   } catch (e) {
     logError('Toolbox', 'registrarConteo', e.message, e.stack, JSON.stringify({ claveProducto, cantidadSistema, cantidadFisico, cpi, vpe, observacion }));
     throw new Error(`Error al registrar conteo: ${e.message}`);
+  }
+}
+
+/**
+ * Registra un arqueo de caja en la hoja 'ArqueoCaja'.
+ * @param {string} userId - ID del usuario que realiza el arqueo.
+ * @param {number} saldoSistema - Monto que debería haber según el sistema.
+ * @param {number} contado - Total contado en efectivo.
+ * @param {number} transferencia - Pagos por transferencia.
+ * @param {number} tarjeta - Pagos con tarjeta.
+ * @param {number} diferencia - Diferencia encontrada.
+ * @param {string} razon - Razón de la diferencia.
+ * @returns {string} Mensaje de confirmación.
+ */
+function registrarArqueoCaja(userId, saldoSistema, contado, transferencia, tarjeta, diferencia, razon) {
+  try {
+    const now = getFormattedTimestamp();
+    const userProfile = obtenerDetallesDeUsuario(userId);
+    const userName = userProfile ? userProfile.Nombre : 'Desconocido';
+    const conteoId = `ARQ-${Date.now()}-${Math.floor(Math.random() * 1000)}`;
+
+    appendRowToSheet(SHEET_NAMES.ARQUEO_CAJA, {
+      ID_Conteo: conteoId,
+      Fecha: now.split(' ')[0],
+      Hora: now.split(' ')[1],
+      UsuarioID: userId,
+      NombreUsuario: userName,
+      'Saldo sistema': saldoSistema,
+      Contado: contado,
+      Transferencia: transferencia,
+      Tarjeta: tarjeta,
+      Diferencia: diferencia,
+      'Razón diferencia': razon || ''
+    });
+
+    return 'Arqueo registrado correctamente.';
+  } catch (e) {
+    logError('Toolbox', 'registrarArqueoCaja', e.message, e.stack, JSON.stringify({ userId, saldoSistema, contado, transferencia, tarjeta, diferencia, razon }));
+    throw new Error(`Error al registrar el arqueo: ${e.message}`);
   }
 }
 


### PR DESCRIPTION
## Resumen
- agregar nombre de hoja `ARQUEO_CAJA`
- crear herramienta **Arqueo de Caja** en la configuración
- implementar `registrarArqueoCaja` en *Toolbox.gs*
- soportar la nueva herramienta en el switch de `ejecutarHerramienta`

## Pruebas
- `echo "Sin pruebas automáticas"`

------
https://chatgpt.com/codex/tasks/task_e_6870622e7d20832d9a8f9aa5feabf32b