### PR TITLE
Corrige variable en registro de arqueo

### DIFF
--- a/Toolbox.gs
+++ b/Toolbox.gs
@@ -442,13 +442,14 @@ function registrarConteo(userId, claveProducto, cantidadSistema, cantidadFisico,
  * @returns {string} Mensaje de confirmación.
  */
 function registrarArqueoCaja(userId, saldoSistema, contado, transferencia, tarjeta, razon) {
+  let diferencia;
   try {
     const now = getFormattedTimestamp();
     const userProfile = obtenerDetallesDeUsuario(userId);
     const userName = userProfile ? userProfile.Nombre : 'Desconocido';
     const conteoId = `ARQ-${Date.now()}-${Math.floor(Math.random() * 1000)}`;
 
-    const diferencia =
+    diferencia =
       (parseFloat(saldoSistema) || 0) -
       (parseFloat(contado) || 0) -
       (parseFloat(transferencia) || 0) -


### PR DESCRIPTION
## Resumen
- declara la variable `diferencia` fuera del bloque `try` en `registrarArqueoCaja`
- asigna la diferencia dentro del `try` para evitar errores en el `catch`

## Pruebas
- `echo "Sin pruebas automáticas"`


------
https://chatgpt.com/codex/tasks/task_e_687077e41888832da351b01fdbec900b