### PR TITLE
Eliminar verificación de tool_calls

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -116,11 +116,6 @@ function limitarHistorial(historial, limiteTokens = MAX_TOKENS_HISTORIAL, limite
       continue;
     }
 
-    if (m.role === 'assistant' && m.tool_calls) {
-      logError('Code', 'limitarHistorial', 'assistant con tool_calls sin respuesta');
-      continue;
-    }
-
     const t = contarTokens(m.content);
     if (result.length >= limiteMensajes || tokens + t > limiteTokens) {
       break;


### PR DESCRIPTION
## Resumen
Se eliminó del archivo `Code.gs` la condición que detenía el flujo cuando un mensaje del asistente contenía `tool_calls`. Esto simplifica la lógica de la función `limitarHistorial`.

## Pruebas
Se ejecutó el comando `echo "Sin pruebas automáticas"` según las indicaciones del proyecto.

------
https://chatgpt.com/codex/tasks/task_e_68708ab7c364832d9f825ff5656925c0