### PR TITLE
Reemplazo de nombre de hoja en controlador

### DIFF
--- a/Controladores.gs
+++ b/Controladores.gs
@@ -23,7 +23,7 @@ function cargarDatosIniciales(userId, pin) {
     }
 
     // 4. Leemos la hoja SÓLO para obtener el Nombre.
-    const usersFromSheet = getSheetData('Usuarios');
+    const usersFromSheet = getSheetData(SHEET_NAMES.USUARIOS);
     const userDynamicData = usersFromSheet.find(u => u.UsuarioID === userId);
 
     if (!userDynamicData || !userDynamicData.Nombre) {


### PR DESCRIPTION
## Resumen
- usar `SHEET_NAMES.USUARIOS` al leer datos de usuario

## Pruebas
- `echo "Sin pruebas automáticas"`

------
https://chatgpt.com/codex/tasks/task_e_687121b5a398832dac64e31664255d20