### PR TITLE
Manejo de errores de herramienta en index

### DIFF
--- a/index.html
+++ b/index.html
@@ -444,7 +444,19 @@ document.addEventListener('DOMContentLoaded', () => {
                         };
                         getAIResponse(payloadForNextStep);
                     })
-                    .withFailureHandler(handleAIError)
+                    .withFailureHandler(error => {
+                        hideTypingIndicator();
+                        showCustomAlert(`Ocurrió un error al procesar tu solicitud: ${error.message}.`, 'error');
+                        messageInput.disabled = false;
+                        sendButton.disabled = false;
+                        messageInput.focus();
+                        const tool_response = {
+                            tool_call_id: toolCall.id,
+                            function_name: functionName,
+                            result: `Error al ejecutar la herramienta: ${error.message}`
+                        };
+                        getAIResponse({ texto: null, tool_response });
+                    })
                     .ejecutarHerramienta(functionName, functionArgs, userId, sessionId);
             }
         } else {
@@ -493,7 +505,19 @@ document.addEventListener('DOMContentLoaded', () => {
                     };
                     getAIResponse(payloadForNextStep);
                 })
-                .withFailureHandler(handleAIError)
+                .withFailureHandler(error => {
+                    hideTypingIndicator();
+                    showCustomAlert(`Ocurrió un error al procesar tu solicitud: ${error.message}.`, 'error');
+                    messageInput.disabled = false;
+                    sendButton.disabled = false;
+                    messageInput.focus();
+                    const tool_response = {
+                        tool_call_id: pending.id,
+                        function_name: pending.name,
+                        result: `Error al ejecutar la herramienta: ${error.message}`
+                    };
+                    getAIResponse({ texto: null, tool_response });
+                })
                 .ejecutarHerramienta(pending.name, pending.args, userId, sessionId);
         } else if (herramientaPendiente && negativePattern.test(userInput)) {
             herramientaPendiente = null;


### PR DESCRIPTION
## Resumen
Se actualizó `index.html` para manejar adecuadamente los errores de las funciones llamadas con `google.script.run.ejecutarHerramienta`. Ahora se muestra un mensaje al usuario, se construye un objeto `tool_response` con la información de la llamada fallida y se envía a `getAIResponse`. Además se mantiene la ocultación del indicador de escritura y el desbloqueo de controles.

## Pruebas
Se ejecutó `echo "Sin pruebas automáticas"`.

------
https://chatgpt.com/codex/tasks/task_e_68712520facc832d9e7d2c4075f4e9ee