### PR TITLE
Extiende búsqueda de frases de registro

### DIFF
--- a/index.html
+++ b/index.html
@@ -392,7 +392,7 @@ document.addEventListener('DOMContentLoaded', () => {
             addMessage(data.content, 'ai');
         }
 
-        const registroRegex = /ya registr(?:e|é)/i;
+        const registroRegex = /(?:ya\s+)?(?:registr(?:e|é)|qued(?:o|ó)\s+registrado|registro\s+completado)/i;
         if (!data.tool_call && data.content && registroRegex.test(data.content)) {
             showCustomAlert('El registro no se completó. Por favor, repetí el proceso.', 'error');
             google.script.run.logError(


### PR DESCRIPTION
## Resumen
- actualiza `registroRegex` para detectar más expresiones de confirmación

## Pruebas
- `echo "Sin pruebas automáticas"`

------
https://chatgpt.com/codex/tasks/task_e_68715e8cba28832dad306899e599ad4a