### PR TITLE
Manejar error de parseo en respuestas AI

### DIFF
--- a/index.html
+++ b/index.html
@@ -412,7 +412,24 @@ document.addEventListener('DOMContentLoaded', () => {
         if (data.tool_call) {
             const toolCall = data.tool_call;
             const functionName = toolCall.function.name;
-            const functionArgs = JSON.parse(toolCall.function.arguments);
+            let functionArgs;
+            try {
+                functionArgs = JSON.parse(toolCall.function.arguments);
+            } catch (e) {
+                showCustomAlert('La respuesta de la IA fue inválida.', 'error');
+                google.script.run.logError(
+                    'Frontend',
+                    'handleAIResponse',
+                    'Error al parsear argumentos',
+                    toolCall.function.arguments,
+                    e.message,
+                    perfilActual?.UsuarioID || 'N/A'
+                );
+                messageInput.disabled = false;
+                sendButton.disabled = false;
+                messageInput.focus();
+                return;
+            }
 
             if (functionName === 'registrarConteo') {
                 herramientaPendiente = {


### PR DESCRIPTION
## Resumen
- controlar el parseo de argumentos de herramientas en `handleAIResponse`
- notificar al usuario cuando la respuesta de IA sea inválida
- registrar el error y reactivar los controles de entrada

## Pruebas
- `echo "Sin pruebas automáticas"`

------
https://chatgpt.com/codex/tasks/task_e_68715f5682c4832d90e5c69292c7a953