### PR TITLE
Corrige detección de registro en preguntas

### DIFF
--- a/index.html
+++ b/index.html
@@ -399,7 +399,8 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         const registroRegex = /(?:ya\s+)?(?:registr(?:e|é)|qued(?:o|ó)\s+registrado|registro\s+completado)/i;
-        if (!data.tool_call && data.content && registroRegex.test(data.content)) {
+        const esPregunta = /[¿?]/.test(data.content);
+        if (!data.tool_call && data.content && registroRegex.test(data.content) && !esPregunta) {
             const herramienta = quickStarterEnUso?.nombreFuncion || 'N/D';
             const claveIntento = `${sessionStorage.getItem('sessionId')}-${herramienta}`;
             const intentos = (intentosFallidos[claveIntento] || 0) + 1;


### PR DESCRIPTION
## Resumen
- evita que el frontend marque como fallido un registro cuando la IA formula la pregunta

## Pruebas
- `echo "Sin pruebas automáticas"`


------
https://chatgpt.com/codex/tasks/task_e_6871c6e004c8832d9856176a7886ea76