### PR TITLE
Añade suma de puntos al registrar arqueo

### DIFF
--- a/Toolbox.gs
+++ b/Toolbox.gs
@@ -473,6 +473,8 @@ function registrarArqueoCaja(userId, saldoSistema, contado, transferencia, tarje
       'Razón diferencia': razon || ''
     });
 
+    sumarPuntos(userId, 10);
+
     return `Arqueo registrado correctamente. Diferencia: ${diferencia}.`;
   } catch (e) {
     logError('Toolbox', 'registrarArqueoCaja', e.message, e.stack, JSON.stringify({ userId, saldoSistema, contado, transferencia, tarjeta, diferencia, razon }));


### PR DESCRIPTION
## Resumen
Se actualizó la función `registrarArqueoCaja` para otorgar puntos al usuario que registra el arqueo de caja.

## Pruebas
```
echo "Sin pruebas automáticas"
```

------
https://chatgpt.com/codex/tasks/task_e_6871f9dcde80832d9d7e41ad99c07131