### PR TITLE
Ajustar puntos por conteo

### DIFF
--- a/Toolbox.gs
+++ b/Toolbox.gs
@@ -9,7 +9,7 @@
 
 const PUNTOS_PROBLEMA = 10;
 const PUNTOS_SUGERENCIA = 15;
-const PUNTOS_CONTEO = 50;
+const PUNTOS_CONTEO = 5;
 const PUNTOS_ARQUEO = 10;
 
 /**
@@ -350,7 +350,7 @@ function registrarMultiplesConteos(conteos, userId) {
         SucursalUsuario: userSucursal
       });
     });
-    sumarPuntos(userId, 5 * conteos.length);
+    sumarPuntos(userId, PUNTOS_CONTEO * conteos.length);
     return `¡Listo! Se registraron ${conteos.length} conteos de inventario.`;
   }
   catch (e) {


### PR DESCRIPTION
## Resumen
- reducir la constante `PUNTOS_CONTEO` a 5
- usar dicha constante al otorgar puntos en `registrarMultiplesConteos`

## Pruebas
- `echo "Sin pruebas automáticas"`

------
https://chatgpt.com/codex/tasks/task_e_6876c234b09c832dbe26c3b0a756ebf6