### PR TITLE
Actualiza rol de usuario U009

### DIFF
--- a/Configuracion.gs
+++ b/Configuracion.gs
@@ -601,7 +601,7 @@ const USUARIOS = [
   },
   {
     UsuarioID: 'U009',
-    Rol: 'Vendedor',
+    Rol: 'Todo en uno',
     Sucursal: 'Cotran',
     Activo: true,
     PIN: '9999',


### PR DESCRIPTION
## Resumen
- Se cambió el rol del usuario **U009** de "Vendedor" a "Todo en uno" en `Configuracion.gs`.

## Pruebas
- `echo "Sin pruebas automáticas"`

------
https://chatgpt.com/codex/tasks/task_e_6876c613ba14832d85cf8d2c232214b4