### PR TITLE
Mover funciones de perfil a módulo dedicado

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -628,23 +628,5 @@ function getAIToolByName(name) {
  */
 
 // --- FUNCIONES DE AYUDA PARA CONTEXTO ---
-
-function getUserProfile(userId) {
-  const profile = obtenerDetallesDeUsuario(userId) || {};
-  return {
-    Nombre: profile.Nombre || '',
-    Rol: profile.Rol || '',
-    Sucursal: profile.Sucursal || '',
-    NotasAdicionales: profile.NotasAdicionales || ''
-  };
-}
-
-function getRoleDetails(roleName) {
-  const rolesData = getSheetData(SHEET_NAMES.ROLES);
-  return rolesData.find(r => r.NombreRol === roleName) || {};
-}
-
-function getBranchDetails(branchName) {
-  const branchesData = getSheetData(SHEET_NAMES.SUCURSALES);
-  return branchesData.find(b => b.NombreSucursal === branchName) || {};
-}
+// Las funciones getUserProfile, getRoleDetails y getBranchDetails
+// se encuentran ahora en DataHelpers.gs

--- a/DataHelpers.gs
+++ b/DataHelpers.gs
@@ -1,0 +1,41 @@
+/**
+ * Proyecto: PlataformaConversacional - Backend en Google Apps Script
+ * Archivo: DataHelpers.gs
+ * Descripción: Funciones de ayuda para obtener datos de usuarios, roles y sucursales.
+ */
+
+/**
+ * Devuelve el perfil del usuario con algunos campos clave.
+ * @param {string} userId - ID del usuario.
+ * @returns {object} Perfil simplificado del usuario.
+ */
+function getUserProfile(userId) {
+  const profile = obtenerDetallesDeUsuario(userId) || {};
+  return {
+    Nombre: profile.Nombre || '',
+    Rol: profile.Rol || '',
+    Sucursal: profile.Sucursal || '',
+    NotasAdicionales: profile.NotasAdicionales || ''
+  };
+}
+
+/**
+ * Obtiene los detalles de un rol específico.
+ * @param {string} roleName - Nombre del rol.
+ * @returns {object} Detalles del rol o un objeto vacío.
+ */
+function getRoleDetails(roleName) {
+  const rolesData = getSheetData(SHEET_NAMES.ROLES);
+  return rolesData.find(r => r.NombreRol === roleName) || {};
+}
+
+/**
+ * Obtiene los detalles de una sucursal específica.
+ * @param {string} branchName - Nombre de la sucursal.
+ * @returns {object} Detalles de la sucursal o un objeto vacío.
+ */
+function getBranchDetails(branchName) {
+  const branchesData = getSheetData(SHEET_NAMES.SUCURSALES);
+  return branchesData.find(b => b.NombreSucursal === branchName) || {};
+}
+


### PR DESCRIPTION
## Resumen
- agregar archivo `DataHelpers.gs` con funciones `getUserProfile`, `getRoleDetails` y `getBranchDetails`
- eliminar esas funciones de `Code.gs` y dejar referencia al nuevo módulo

## Pruebas
- `echo "Sin pruebas automáticas"`

------
https://chatgpt.com/codex/tasks/task_e_6876d73d0ffc832d8ed0deb918dd685d