### PR TITLE
Manejar cancelación de herramienta

### DIFF
--- a/index.html
+++ b/index.html
@@ -558,8 +558,15 @@ document.addEventListener('DOMContentLoaded', () => {
                 })
                 .ejecutarHerramienta(pending.name, pending.args, userId, sessionId);
         } else if (herramientaPendiente && negativePattern.test(userInput)) {
+            const pending = herramientaPendiente;
             herramientaPendiente = null;
             addMessage('Operación cancelada.', 'system');
+            const tool_response = {
+                tool_call_id: pending.id,
+                function_name: pending.name,
+                result: 'Operación cancelada'
+            };
+            getAIResponse({ texto: null, tool_response });
         } else {
             getAIResponse({ texto: userInput });
         }


### PR DESCRIPTION
## Resumen
Se actualizó la función de envío de mensajes en `index.html` para que, al detectar una respuesta negativa ante una herramienta pendiente, se genere un `tool_response` ficticio que indique la cancelación y se envíe a `getAIResponse`.

## Pruebas
```
echo "Sin pruebas automáticas"
```

------
https://chatgpt.com/codex/tasks/task_e_6876f78dc678832dbdc694829ace83fc