### PR TITLE
Actualiza patrones para respuestas en index

### DIFF
--- a/index.html
+++ b/index.html
@@ -520,8 +520,9 @@ document.addEventListener('DOMContentLoaded', () => {
         addMessage(userInput, 'user');
         messageInput.value = '';
 
-        const affirmativePattern = /^(sí|si|claro|dale|ok)/i;
-        const negativePattern = /^(no|cancel)/i;
+        // Expresiones para interpretar respuestas positivas o negativas
+        const affirmativePattern = /^(?:s[ií]p?|claro|dale|ok(?:ay|ey)?|va|vale|listo|de acuerdo|afirmativo)/i;
+        const negativePattern = /^(?:no|nop|nope|cancel(?:ar|ado)?|cancela|cancelaci(?:ó|o)n|negativo)/i;
 
         if (herramientaPendiente && affirmativePattern.test(userInput)) {
             const pending = herramientaPendiente;


### PR DESCRIPTION
## Resumen
- se amplían las expresiones regulares de `affirmativePattern` y `negativePattern` en `index.html`
- ahora se contemplan más variantes comunes con y sin acento

## Pruebas
- `echo "Sin pruebas automáticas"`


------
https://chatgpt.com/codex/tasks/task_e_6876f79487e8832d85af620ddc469caf