### PR TITLE
Agrega limpieza automática de sesiones

### DIFF
--- a/Configuracion.gs
+++ b/Configuracion.gs
@@ -11,6 +11,7 @@ const TEMPERATURA_AI = 0.5;
 const MAX_TOKENS_AI = 4000; // Aumentado para aprovechar el nuevo modelo
 const MAX_TOKENS_HISTORIAL = 6000; // Se amplía el historial permitido
 const MAX_MENSAJES_HISTORIAL = 80;  // Cantidad máxima de mensajes en el historial
+const HORAS_INACTIVIDAD_SESION = 12; // Tiempo en horas para cerrar sesiones
 
 
 const OPENAI_API_URL = "https://api.openai.com/v1/chat/completions";

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ obtenida con `obtenerRankingPuntos()`.
 3. Define una **propiedad de script** llamada `OPENAI_API_KEY` con tu clave de OpenAI.
 4. Ajusta el valor de `ID_HOJA_PUENTE` en `Configuracion.gs` para que apunte al ID de tu hoja principal.
 5. Desde el editor de Apps Script selecciona **Deploy > New deployment** y elige "Web app" para publicar la aplicación. `doGet()` sirve la interfaz `index.html`.
+6. Ejecuta `instalarTriggerLimpiezaSesiones` para programar la limpieza de sesiones.
 
 ## Ejecución de la suite de pruebas
 

--- a/Sesiones.gs
+++ b/Sesiones.gs
@@ -1,0 +1,39 @@
+/**
+ * Funciones de mantenimiento para las sesiones de chat.
+ */
+
+/**
+ * Revisa las sesiones y marca como inactivas las que superen
+ * HORAS_INACTIVIDAD_SESION sin actividad. También limpia su historial.
+ */
+function limpiarSesionesInactivas() {
+  try {
+    const sesiones = getSheetData(SHEET_NAMES.SESIONES);
+    const ahora = new Date();
+    const limiteMs = HORAS_INACTIVIDAD_SESION * 60 * 60 * 1000;
+
+    sesiones.forEach(s => {
+      const ultima = parseSafeDate(s.UltimaActividad);
+      if (!ultima) return;
+
+      if (ahora.getTime() - ultima.getTime() > limiteMs && s.EstadoSesion !== 'Inactiva') {
+        updateRowInSheet(SHEET_NAMES.SESIONES, 'SesionID', s.SesionID, {
+          EstadoSesion: 'Inactiva',
+          HistorialConversacion: ''
+        });
+      }
+    });
+  } catch (e) {
+    Logging.logError('Backend', 'limpiarSesionesInactivas', e.message, e.stack);
+  }
+}
+
+/**
+ * Instala un disparador horario para limpiar sesiones inactivas.
+ */
+function instalarTriggerLimpiezaSesiones() {
+  ScriptApp.newTrigger('limpiarSesionesInactivas')
+    .timeBased()
+    .everyHours(1)
+    .create();
+}


### PR DESCRIPTION
## Resumen
- define `HORAS_INACTIVIDAD_SESION` en la configuración
- crea `Sesiones.gs` con funciones para limpiar las sesiones y el disparador
- actualiza las instrucciones de despliegue en el README

## Pruebas
- `echo "Sin pruebas automáticas"`


------
https://chatgpt.com/codex/tasks/task_e_6876f7a57438832dbcc158e05a808a86