### PR TITLE
Actualiza selección de herramientas

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -114,11 +114,13 @@ function prepararPayload(userProfile, roleDetails, branchDetails, chatHistory, p
   const selectedToolName = payload.tool_name;
   let tools = [];
   let promptExtra = '';
+  let toolChoice = 'auto';
 
   if (selectedToolName) {
     const tool = getAIToolByName(selectedToolName);
     if (tool) {
       tools.push(tool);
+      toolChoice = { type: 'function', function: { name: selectedToolName } };
       if (tool.PromptEspecifico) promptExtra += tool.PromptEspecifico;
       if (tool.ComportamientoAdicional) {
         if (promptExtra) promptExtra += '\n';
@@ -141,7 +143,7 @@ function prepararPayload(userProfile, roleDetails, branchDetails, chatHistory, p
     temperature: TEMPERATURA_AI,
     max_tokens: MAX_TOKENS_AI,
     tools: tools,
-    tool_choice: 'auto'
+    tool_choice: toolChoice
   };
 
   return { requestPayload: requestPayload, chatHistory: chatHistory };


### PR DESCRIPTION
## Resumen
- ajusta `prepararPayload` para enviar `tool_choice` sólo cuando se indica una herramienta
- mantiene selección automática en los demás casos

## Pruebas
- `echo "Sin pruebas automáticas"`


------
https://chatgpt.com/codex/tasks/task_e_687702a61138832dab9873d43900e9ae