### PR TITLE
Elimina variable sin uso en Code.gs

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -47,7 +47,6 @@ function obtenerHistorialReciente(userId, sesionActual) {
   try {
     const sesiones = getSheetData(SHEET_NAMES.SESIONES)
       .filter(s => s.UsuarioID === userId && s.SesionID !== sesionActual);
-    const tz = SpreadsheetApp.getActiveSpreadsheet().getSpreadsheetTimeZone();
     const fechaLimite = new Date();
     fechaLimite.setDate(fechaLimite.getDate() - 2);
     const historial = [];


### PR DESCRIPTION
## Resumen
- se retiró la declaración innecesaria de `tz` en `obtenerHistorialReciente`

## Pruebas
- `echo "Sin pruebas automáticas"`


------
https://chatgpt.com/codex/tasks/task_e_6877bf6a1930832da748212c5b2d180d