### PR TITLE
Corregir flujo del quick starter

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -119,7 +119,7 @@ function prepararPayload(userProfile, roleDetails, branchDetails, chatHistory, p
     const info = getAIToolByName(selectedToolName);
     if (info) {
       tools.push(info.herramienta);
-      toolChoice = { type: 'function', function: { name: selectedToolName } };
+      // No forzar la llamada inmediata a la herramienta
       if (info.prompt) promptExtra += info.prompt;
       if (info.comportamiento) {
         if (promptExtra) promptExtra += '\n';


### PR DESCRIPTION
## Resumen
Se ajustó `prepararPayload` para que las acciones rápidas no ejecuten de inmediato la herramienta seleccionada. Ahora se incluye la herramienta en la solicitud pero se mantiene `tool_choice` en `auto`, permitiendo a la IA recopilar los datos antes de llamar la función.

## Pruebas
Se ejecutó:
```
echo "Sin pruebas automáticas"
```


------
https://chatgpt.com/codex/tasks/task_e_68788dc1c55c832d8812ede9e87ed2bb