### PR TITLE
Mejora coherencia del mensaje al iniciar sesión

### DIFF
--- a/Controladores.gs
+++ b/Controladores.gs
@@ -104,7 +104,7 @@ function cargarDatosIniciales(userId, pin) {
       const revision = revisionMetaConteo(perfil.UsuarioID);
       const mensajePersonalizado =
         `Hola ${perfil.Nombre}, bienvenido seas el día de hoy. ` +
-        `Ayer hicimos ${resumenChat}, ¿qué haremos hoy?`;
+        `Ayer me comentaste lo siguiente: ${resumenChat} ¿qué haremos hoy?`;
       responseData.mensajeAnuncio = [
         ...welcomeMessage,
         ...anunciosActivos,


### PR DESCRIPTION
## Resumen
- Ajuste en `cargarDatosIniciales` para que el mensaje personalizado integre el resumen del chat de forma coherente.

## Pruebas
- `echo "Sin pruebas automáticas"`

------
https://chatgpt.com/codex/tasks/task_e_687a76f8e8f4832dbd2fb62c9f28be10