### PR TITLE
Hacer visible el panel para todos

### DIFF
--- a/AdminPanel.gs
+++ b/AdminPanel.gs
@@ -12,11 +12,21 @@
  * Obtiene y procesa ÚNICAMENTE los mensajes de la hoja local 'Mensajes'.
  * @returns {Array<object>} Una lista de ítems de mensajes.
  */
-function obtenerPanelAdminData_SoloMensajes() {
+function obtenerPanelAdminData_SoloMensajes(userId) {
   Logger.log('--- INICIANDO obtenerPanelAdminData_SoloMensajes ---');
   try {
     Logger.log('Paso 1: Leyendo datos de la hoja local "Mensajes"...');
-    const mensajes = getSheetData(SHEET_NAMES.MENSAJES);
+    const todosMensajes = getSheetData(SHEET_NAMES.MENSAJES);
+    Logger.log('Paso 1b: Leyendo datos de "MensajeColaborador"...');
+    let relacion = getSheetData(SHEET_NAMES.MENSAJE_COLABORADOR);
+    const perfil = obtenerDetallesDeUsuario(userId);
+    const esAdmin = perfil && perfil.Rol === 'Administrador';
+    if (!esAdmin) {
+      relacion = relacion.filter(r => r.ColaboradorID === userId);
+    }
+    const idsPermitidos = relacion.map(r => r.ID_Mensaje);
+    const mensajes = esAdmin ? todosMensajes
+      : todosMensajes.filter(m => idsPermitidos.includes(m.ID_Mensaje));
     Logger.log(` -> Se encontraron ${mensajes.length} mensajes brutos.`);
 
     Logger.log('Paso 2: Mapeando y estandarizando ítems de Mensajes...');

--- a/Configuracion.gs
+++ b/Configuracion.gs
@@ -34,7 +34,8 @@ const SHEET_NAMES = {
   CONFIGURACION_AI: 'ConfiguracionAI',
   PROMPTS_AI: 'PromptsAI',
   HERRAMIENTAS_AI: 'HerramientasAI',
-  ARQUEO_CAJA: 'ArqueoCaja'
+  ARQUEO_CAJA: 'ArqueoCaja',
+  MENSAJE_COLABORADOR: 'MensajeColaborador'
 };
 
 

--- a/Test.gs
+++ b/Test.gs
@@ -178,7 +178,7 @@ function testAdminPanelLogic() {
   // 4.2: Prueba de obtenerPanelAdminData_SoloMensajes
   try {
     Logger.log('   - Probando: obtenerPanelAdminData_SoloMensajes()...');
-    const mensajesAdminData = obtenerPanelAdminData_SoloMensajes();
+    const mensajesAdminData = obtenerPanelAdminData_SoloMensajes(TEST_ADMIN_USER_ID);
     if (mensajesAdminData.length > 0) {
       Logger.log(`     ✅ Éxito. Se cargaron ${mensajesAdminData.length} ítems de mensajes para el panel.`);
       Logger.log(`     Primer mensaje: ${JSON.stringify(mensajesAdminData[0], null, 2)}`);

--- a/Toolbox.gs
+++ b/Toolbox.gs
@@ -42,6 +42,14 @@ function registrarMensaje(tipo, userId, asunto, detalle, sessionId, puntos) {
     AdminRespondiendoID: ''
   });
 
+  appendRowToSheet(SHEET_NAMES.MENSAJE_COLABORADOR, {
+    ColaboradorID: userId,
+    NombreColaborador: userName,
+    ID_Mensaje: messageId,
+    UsuarioRemitenteID: userId,
+    NombreRemitente: userName
+  });
+
   if (puntos) {
     sumarPuntos(userId, puntos);
   }

--- a/index.html
+++ b/index.html
@@ -338,17 +338,12 @@ document.addEventListener('DOMContentLoaded', () => {
             datos.mensajeAnuncio.forEach((msg, i) => setTimeout(() => addMessage(msg, 'system'), 500 * (i + 1)));
         }
 
-        if (perfilActual.Rol === "Administrador") {
-            adminViewSwitcher.classList.remove('hidden');
-            showChatBtn.addEventListener('click', () => updateActiveView('chat'));
-            showAdminPanelBtn.addEventListener('click', () => updateActiveView('admin'));
-            updateActiveView('chat');
-            renderAdminPanel();
-            refrescarPanelAdmin();
-        } else {
-            adminViewSwitcher.classList.add('hidden');
-            updateActiveView('chat');
-        }
+        adminViewSwitcher.classList.remove('hidden');
+        showChatBtn.addEventListener('click', () => updateActiveView('chat'));
+        showAdminPanelBtn.addEventListener('click', () => updateActiveView('admin'));
+        updateActiveView('chat');
+        renderAdminPanel();
+        refrescarPanelAdmin();
 
         messageInput.disabled = false;
         sendButton.disabled = false;
@@ -759,7 +754,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     container.innerHTML = `<p class="text-red-400 text-center text-sm p-4">Error al cargar datos: ${err.message}</p>`;
                 }
             })
-            .obtenerPanelAdminData_SoloMensajes();
+            .obtenerPanelAdminData_SoloMensajes(perfilActual.UsuarioID);
     }
 
     function renderFilteredAdminItems() {


### PR DESCRIPTION
## Resumen
- agregar la hoja `MensajeColaborador` a la configuración
- registrar cada mensaje también en `MensajeColaborador`
- filtrar los mensajes del panel según el usuario activo
- mostrar el panel de administrador a todos los usuarios

## Pruebas
- `echo "Sin pruebas automáticas"`

------
https://chatgpt.com/codex/tasks/task_e_687fe53e2bd8832dab2e7921c876bb0d