### PR TITLE
Arreglo de error de sintaxis

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -130,6 +130,7 @@ function prepararPayload(userProfile, roleDetails, branchDetails, chatHistory, p
   }
 
   const extra = Array.isArray(historialExtra) ? historialExtra : obtenerHistorialReciente(userId, sessionId);
+  chatHistory = limitarHistorial([
     { role: 'system', content: finalSystemPrompt + (promptExtra ? '\n' + promptExtra : '') },
     ...extra,
     ...chatHistory


### PR DESCRIPTION
## Resumen
Se corrigió un problema en `prepararPayload` donde faltaba la llamada a `limitarHistorial`. Esto provocaba un `SyntaxError` por un token inesperado.

## Pruebas
```
Sin pruebas automáticas
```

------
https://chatgpt.com/codex/tasks/task_e_687fed7d303c832da9d12fa37669d480