### PR TITLE
Implementa subida de imágenes

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -458,6 +458,20 @@ function ejecutarHerramienta(functionName, functionArgs, userId, sessionId) {
   }
 }
 
+/**
+ * Sube una imagen en base64 a Drive y devuelve su URL pública.
+ * @param {string} base64 - Cadena de la imagen codificada en base64.
+ * @param {string} nombre - Nombre del archivo a guardar.
+ * @returns {string} URL del archivo accesible públicamente.
+ */
+function subirImagen(base64, nombre) {
+  const blob = Utilities.newBlob(Utilities.base64Decode(base64), undefined, nombre);
+  const folder = DriveApp.getFolderById(FOLDER_IMAGENES);
+  const file = folder.createFile(blob);
+  file.setSharing(DriveApp.Access.ANYONE_WITH_LINK, DriveApp.Permission.VIEW);
+  return file.getUrl();
+}
+
 // --- LÓGICA DE CALENDARIO DE CONTEO Y REGISTRO DE CONTEOS ---
 
 /**

--- a/Configuracion.gs
+++ b/Configuracion.gs
@@ -16,6 +16,7 @@ const HORAS_INACTIVIDAD_SESION = 12; // Tiempo en horas para cerrar sesiones
 
 const OPENAI_API_URL = "https://api.openai.com/v1/chat/completions";
 const ID_HOJA_PUENTE = '1nj2UfUPK5xQg6QI68j9ArLss-ptrlaN3PY8NMOr_Jhg';
+const FOLDER_IMAGENES = '1bGeMwmGdXOYrnUs0Pr7FcXhtRY9iaY_M';
 
 // ===============================================================
 // ==== CENTRALIZACIÓN DE NOMBRES DE HOJAS ====

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ Las insignias se guardan con la función `asignarInsignia(userId, nombreInsignia
 En la interfaz se muestra el puntaje actual y una tabla de clasificación,
 obtenida con `obtenerRankingPuntos()`.
 
+## Subida de imágenes
+
+En el formulario de chat hay un campo para elegir archivos de imagen y un botón
+dedicado para enviarlas. Al seleccionar una imagen se convierte a base64 y se
+envía a la función `subirImagen`, que la guarda en la carpeta indicada por
+`FOLDER_IMAGENES` y devuelve su URL pública. Esa URL se muestra en el chat como
+la imagen subida.
+
 
 ## Despliegue
 

--- a/index.html
+++ b/index.html
@@ -147,7 +147,11 @@
                 <div id="suggestions-container" class="px-4 pb-2"></div>
                 <footer class="p-4 border-t border-slate-700">
                     <form id="chat-form" class="relative">
-                        <input type="text" id="message-input" placeholder="Escribe tu mensaje aquí..." class="w-full bg-slate-700 border border-slate-600 rounded-xl py-3 pl-4 pr-12 text-slate-200 focus:outline-none focus:ring-2 focus:ring-emerald-500 transition-shadow" autocomplete="off">
+                        <input type="text" id="message-input" placeholder="Escribe tu mensaje aquí..." class="w-full bg-slate-700 border border-slate-600 rounded-xl py-3 pl-4 pr-24 text-slate-200 focus:outline-none focus:ring-2 focus:ring-emerald-500 transition-shadow" autocomplete="off">
+                        <input type="file" id="image-upload" accept="image/*" class="hidden">
+                        <button type="button" id="send-image-button" class="absolute right-12 top-1/2 -translate-y-1/2 bg-emerald-600 hover:bg-emerald-500 w-9 h-9 rounded-lg flex items-center justify-center transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-800 focus-visible:ring-white" aria-label="Enviar Imagen">
+                            <span class="material-symbols-outlined text-white">image</span>
+                        </button>
                         <button type="submit" id="send-button" class="absolute right-2 top-1/2 -translate-y-1/2 bg-emerald-600 hover:bg-emerald-500 w-9 h-9 rounded-lg flex items-center justify-center transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-800 focus-visible:ring-white" aria-label="Enviar Mensaje">
                             <span class="material-symbols-outlined text-white">send</span>
                         </button>
@@ -234,6 +238,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const chatForm = document.getElementById('chat-form');
     const messageInput = document.getElementById('message-input');
     const sendButton = document.getElementById('send-button');
+    const imageUpload = document.getElementById('image-upload');
+    const sendImageButton = document.getElementById('send-image-button');
 
     // Modales
     const modalContainer = document.getElementById('modal-container');
@@ -429,6 +435,25 @@ document.addEventListener('DOMContentLoaded', () => {
         chatWindow.scrollTop = chatWindow.scrollHeight;
     }
 
+    function addImageMessage(url, sender = 'user') {
+        const container = document.createElement('div');
+        container.className = `flex message-bubble ${sender === 'user' ? 'justify-end' : 'justify-start'}`;
+        const bubble = document.createElement('div');
+        bubble.className = 'max-w-xs rounded-2xl overflow-hidden shadow-md';
+        if (sender === 'user') {
+            bubble.classList.add('bg-blue-600');
+        } else {
+            bubble.classList.add('bg-slate-700');
+        }
+        const img = document.createElement('img');
+        img.src = url;
+        img.className = 'block w-full h-auto';
+        bubble.appendChild(img);
+        container.appendChild(bubble);
+        chatWindow.appendChild(container);
+        chatWindow.scrollTop = chatWindow.scrollHeight;
+    }
+
     function showTypingIndicator() {
         if (document.getElementById('typing-indicator')) return;
         const indicator = document.createElement('div');
@@ -594,6 +619,28 @@ document.addEventListener('DOMContentLoaded', () => {
         sendButton.disabled = false;
         messageInput.focus();
     }
+
+    sendImageButton.addEventListener('click', () => {
+        const file = imageUpload.files[0];
+        if (!file) {
+            showCustomAlert('Seleccioná una imagen primero.', 'info');
+            return;
+        }
+        const reader = new FileReader();
+        reader.onload = () => {
+            const base64 = reader.result.split(',')[1];
+            google.script.run
+                .withSuccessHandler(url => {
+                    addImageMessage(url, 'user');
+                    imageUpload.value = '';
+                })
+                .withFailureHandler(err => {
+                    showCustomAlert(`Error al subir imagen: ${err.message}`, 'error');
+                })
+                .subirImagen(base64, file.name);
+        };
+        reader.readAsDataURL(file);
+    });
 
     chatForm.addEventListener('submit', (e) => {
         e.preventDefault();


### PR DESCRIPTION
## Resumen
- define la carpeta de imágenes en `Configuracion.gs`
- crea la función `subirImagen` para guardar imágenes en Drive
- agrega en la interfaz un campo para elegir imágenes y un botón para enviarlas
- muestra la imagen subida en el chat
- documenta el proceso en `README.md`

## Pruebas
- `echo "Sin pruebas automáticas"`

------
https://chatgpt.com/codex/tasks/task_e_6880309f8f00832da08586ef6fb7de40