### PR TITLE
Mejora visual del panel de admin

### DIFF
--- a/AdminPanel.gs
+++ b/AdminPanel.gs
@@ -32,6 +32,9 @@ function obtenerPanelAdminData_SoloMensajes(userId) {
     Logger.log('Paso 2: Mapeando y estandarizando ítems de Mensajes...');
     const itemsMensajes = mensajes.map(m => {
       const fechaObj = parseSafeDate(m.FechaHora);
+      const colabs = relacion
+        .filter(r => r.ID_Mensaje === m.ID_Mensaje)
+        .map(r => ({ id: r.ColaboradorID, nombre: r.NombreColaborador }));
       const item = {
         id: m.ID_Mensaje,
         tipo: m.TipoMensaje,
@@ -39,7 +42,8 @@ function obtenerPanelAdminData_SoloMensajes(userId) {
         usuario: `${m.NombreRemitente} (${m.UsuarioRemitenteID})`,
         asunto: m.Asunto,
         detalle: m.Detalle,
-        estado: m.Estado
+        estado: m.Estado,
+        colaboradores: colabs
       };
       return item;
     });

--- a/index.html
+++ b/index.html
@@ -885,17 +885,40 @@ document.addEventListener('DOMContentLoaded', () => {
             const statusColor = item.estado === 'Pendiente' ? 'bg-yellow-500/20 text-yellow-300' : 'bg-green-500/20 text-green-300';
             const tipoIcono = { Problema: 'report', Sugerencia: 'lightbulb', Tarea: 'task_alt', Caja: 'payments' }[item.tipo] || 'folder';
             return `
-                <div class="bg-slate-900 p-3 rounded-lg border border-slate-700">
+                <div class="bg-slate-800 p-4 rounded-lg border border-slate-700 flex flex-col gap-3">
                     <div class="flex justify-between items-start">
-                        <p class="font-bold text-white text-sm pr-2 flex items-center"><span class="material-symbols-outlined text-base mr-2">${tipoIcono}</span> ${item.asunto || 'Sin asunto'}</p>
-                        <span class="text-xs ${statusColor} px-2 py-0.5 rounded-full whitespace-nowrap">${item.estado}</span>
+                        <p class="font-bold text-white text-base pr-2 flex items-center">
+                            <span class="material-symbols-outlined text-xl mr-2">${tipoIcono}</span>
+                            ${item.asunto || 'Sin asunto'}
+                        </p>
+                        <span class="text-xs ${statusColor} px-2.5 py-1 rounded-full font-semibold whitespace-nowrap">${item.estado}</span>
                     </div>
-                    <p class="text-xs text-slate-400 mt-1 mb-2 break-words">${item.detalle || ''}</p>
-                    <div class="flex justify-between items-center text-xs text-slate-500">
-                        <span>${item.usuario || 'N/A'} - ${item.fecha?.toLocaleDateString('es-NI') || 'Sin fecha'}</span>
-                        ${item.estado === 'Pendiente' ? `<button data-item-id="${item.id}" class="btn-marcar-revisado px-2 py-1 bg-slate-700 hover:bg-slate-600 text-white rounded text-xs">Marcar Revisado</button>` : ''}
-                        <button data-item-id="${item.id}" class="btn-add-collab ml-2 px-2 py-1 bg-emerald-700 hover:bg-emerald-600 text-white rounded text-xs">Agregar Colaborador</button>
-                        <button data-item-id="${item.id}" class="btn-chat ml-2 px-2 py-1 bg-blue-700 hover:bg-blue-600 text-white rounded text-xs">Comentarios</button>
+
+                    <p class="text-sm text-slate-400 break-words">${item.detalle || 'Sin detalle.'}</p>
+
+                    <div class="flex justify-between items-center mt-2">
+                        <div class="flex items-center gap-2">
+                            <div class="flex items-center gap-2 text-xs text-slate-500">
+                                <div class="w-6 h-6 bg-emerald-500 rounded-full flex items-center justify-center text-white font-bold text-xs">
+                                    ${(item.usuario || 'N/A').charAt(0)}
+                                </div>
+                                <span>${item.usuario || 'N/A'} &bull; ${item.fecha?.toLocaleDateString('es-NI') || 'Sin fecha'}</span>
+                            </div>
+                            ${item.colaboradores && item.colaboradores.length > 0 ? `
+                            <div class="flex items-center -space-x-2">
+                                ${item.colaboradores.map(colab => `
+                                    <div class="w-6 h-6 bg-sky-500 rounded-full flex items-center justify-center text-white font-bold text-xs border-2 border-slate-800" title="${colab.nombre}">
+                                        ${colab.nombre.charAt(0)}
+                                    </div>
+                                `).join('')}
+                            </div>
+                            ` : ''}
+                        </div>
+                        <div class="flex items-center gap-2">
+                            ${item.estado === 'Pendiente' ? `<button data-item-id="${item.id}" class="btn-marcar-revisado px-2 py-1 bg-slate-700 hover:bg-slate-600 text-white rounded text-xs">Marcar Revisado</button>` : ''}
+                            <button data-item-id="${item.id}" class="btn-add-collab px-2 py-1 bg-emerald-700 hover:bg-emerald-600 text-white rounded text-xs">Agregar Colaborador</button>
+                            <button data-item-id="${item.id}" class="btn-chat px-2 py-1 bg-blue-700 hover:bg-blue-600 text-white rounded text-xs">Comentarios</button>
+                        </div>
                     </div>
                 </div>`;
         }).join('');


### PR DESCRIPTION
## Resumen
- incluir colaboradores en los datos de mensajes
- renovar diseño de tarjetas del panel de administración
- mostrar avatares de colaboradores asignados

## Pruebas
- `echo "Sin pruebas automáticas"`


------
https://chatgpt.com/codex/tasks/task_e_6880409d5994832db5925c97d5b54088