### PR TITLE
Agrega compresión y señal al subir imágenes

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -469,7 +469,7 @@ function subirImagen(base64, nombre) {
   const folder = DriveApp.getFolderById(FOLDER_IMAGENES);
   const file = folder.createFile(blob);
   file.setSharing(DriveApp.Access.ANYONE_WITH_LINK, DriveApp.Permission.VIEW);
-  return file.getUrl();
+  return `https://drive.google.com/uc?export=view&id=${file.getId()}`;
 }
 
 // --- LÓGICA DE CALENDARIO DE CONTEO Y REGISTRO DE CONTEOS ---

--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ Para adjuntar capturas desde la interfaz seguí estos pasos:
 
 1. Hacé clic en el botón **Seleccionar archivo** debajo del cuadro de texto.
 2. Elegí la imagen a cargar y presioná **Enviar imagen**.
-3. La aplicación convierte la imagen a base64 y llama a `subirImagen`.
+3. La aplicación comprime la imagen, la convierte a base64 y llama a
+   `subirImagen`.
 4. La función guarda el archivo en la carpeta de Drive **ImagenesFerrebot** y
-   devuelve su enlace público para mostrarlo en el chat.
+   devuelve un enlace directo para mostrarlo en el chat.
 
 La carpeta **ImagenesFerrebot** debe existir en tu Google Drive y su ID se
 configura en `FOLDER_IMAGENES`. La cuenta que ejecuta el script necesita permiso

--- a/index.html
+++ b/index.html
@@ -469,6 +469,48 @@ document.addEventListener('DOMContentLoaded', () => {
         document.getElementById('typing-indicator')?.remove();
     }
 
+    function showUploadIndicator() {
+        if (document.getElementById('upload-indicator')) return;
+        const indicator = document.createElement('div');
+        indicator.id = 'upload-indicator';
+        indicator.className = 'flex justify-end message-bubble';
+        indicator.innerHTML = `<div class="bg-blue-600 text-white rounded-2xl px-4 py-2.5 shadow-md flex items-center gap-2"><span class="material-symbols-outlined animate-spin">cloud_upload</span><span class="text-sm">Subiendo imagen...</span></div>`;
+        chatWindow.appendChild(indicator);
+        chatWindow.scrollTop = chatWindow.scrollHeight;
+    }
+
+    function hideUploadIndicator() {
+        document.getElementById('upload-indicator')?.remove();
+    }
+
+    function compressImage(file, callback) {
+        const reader = new FileReader();
+        reader.onload = e => {
+            const img = new Image();
+            img.onload = () => {
+                const canvas = document.createElement('canvas');
+                let width = img.width;
+                let height = img.height;
+                const maxDim = 1280;
+                if (width > height && width > maxDim) {
+                    height = Math.round(height * maxDim / width);
+                    width = maxDim;
+                } else if (height >= width && height > maxDim) {
+                    width = Math.round(width * maxDim / height);
+                    height = maxDim;
+                }
+                canvas.width = width;
+                canvas.height = height;
+                const ctx = canvas.getContext('2d');
+                ctx.drawImage(img, 0, 0, width, height);
+                const dataUrl = canvas.toDataURL('image/jpeg', 0.7);
+                callback(dataUrl.split(',')[1]);
+            };
+            img.src = e.target.result;
+        };
+        reader.readAsDataURL(file);
+    }
+
     function getAIResponse(payload) {
         messageInput.disabled = true;
         sendButton.disabled = true;
@@ -622,20 +664,20 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function subirImagenSeleccionada(file) {
-        const reader = new FileReader();
-        reader.onload = () => {
-            const base64 = reader.result.split(',')[1];
+        showUploadIndicator();
+        compressImage(file, base64 => {
             google.script.run
                 .withSuccessHandler(url => {
+                    hideUploadIndicator();
                     addImageMessage(url, 'user');
                     imageUpload.value = '';
                 })
                 .withFailureHandler(err => {
+                    hideUploadIndicator();
                     showCustomAlert(`Error al subir imagen: ${err.message}`, 'error');
                 })
                 .subirImagen(base64, file.name);
-        };
-        reader.readAsDataURL(file);
+        });
     }
 
     sendImageButton.addEventListener('click', () => {


### PR DESCRIPTION
## Resumen
- se comprime la imagen antes de enviarla al backend
- se muestra un indicador de carga mientras se sube
- se usa un enlace directo desde Drive para mostrar la imagen
- se actualiza la documentación

## Pruebas
- `echo "Sin pruebas automáticas"`

------
https://chatgpt.com/codex/tasks/task_e_6880496e2cfc832d9d7417834091f5e7