### PR TITLE
Añadir estados y acciones rápidas para mensajes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ configura en `FOLDER_IMAGENES`. La cuenta que ejecuta el script necesita permiso
 de edición sobre esa carpeta y autorizar el acceso a Drive al desplegar la
 aplicación.
 
+## Acciones rápidas en el chat
+
+Cada burbuja de conversación incluye cuatro iconos:
+
+- **check** para aprobar un mensaje.
+- **visibility** para marcarlo como visto.
+- **lightbulb** para destacarlo como idea.
+- **push_pin** para fijarlo en la lista.
+
+Al hacer clic se llaman las funciones correspondientes en el backend,
+por ejemplo `marcarMensajeAprobado(id)` o `fijarMensaje(id)`.
+
 
 ## Despliegue
 

--- a/Toolbox.gs
+++ b/Toolbox.gs
@@ -39,7 +39,11 @@ function registrarMensaje(tipo, userId, asunto, detalle, sessionId, puntos) {
     Estado: 'Pendiente',
     RespuestaAdmin: '',
     FechaHoraRespuesta: '',
-    AdminRespondiendoID: ''
+    AdminRespondiendoID: '',
+    Aprobado: false,
+    Visto: false,
+    Destacado: false,
+    Fijado: false
   });
 
   appendRowToSheet(SHEET_NAMES.MENSAJE_COLABORADOR, {
@@ -968,6 +972,66 @@ function asignarInsignia(userId, nombreInsignia) {
   } catch (e) {
     Logging.logError('Toolbox', 'asignarInsignia', e.message, e.stack, JSON.stringify({ userId, nombreInsignia }));
   }
+}
+
+/**
+ * Marca un mensaje como aprobado.
+ * @param {string} messageId - ID del mensaje.
+ * @returns {string} Confirmación.
+ */
+function marcarMensajeAprobado(messageId) {
+  const ok = updateRowInSheet(SHEET_NAMES.MENSAJES, 'ID_Mensaje', messageId, {
+    Aprobado: true
+  });
+  if (!ok) {
+    throw new Error('No se encontró el mensaje.');
+  }
+  return 'Mensaje aprobado.';
+}
+
+/**
+ * Marca un mensaje como visto.
+ * @param {string} messageId - ID del mensaje.
+ * @returns {string} Confirmación.
+ */
+function marcarMensajeVisto(messageId) {
+  const ok = updateRowInSheet(SHEET_NAMES.MENSAJES, 'ID_Mensaje', messageId, {
+    Visto: true
+  });
+  if (!ok) {
+    throw new Error('No se encontró el mensaje.');
+  }
+  return 'Mensaje marcado como visto.';
+}
+
+/**
+ * Destaca un mensaje como idea.
+ * @param {string} messageId - ID del mensaje.
+ * @returns {string} Confirmación.
+ */
+function marcarMensajeDestacado(messageId) {
+  const ok = updateRowInSheet(SHEET_NAMES.MENSAJES, 'ID_Mensaje', messageId, {
+    Destacado: true
+  });
+  if (!ok) {
+    throw new Error('No se encontró el mensaje.');
+  }
+  return 'Mensaje destacado.';
+}
+
+/**
+ * Fija un mensaje en la lista.
+ * @param {string} messageId - ID del mensaje.
+ * @returns {string} Confirmación.
+ */
+function fijarMensaje(messageId) {
+  const ok = updateRowInSheet(SHEET_NAMES.MENSAJES, 'ID_Mensaje', messageId, {
+    Fijado: true
+  });
+  if (!ok) {
+    throw new Error('No se encontró el mensaje.');
+  }
+  return 'Mensaje fijado.';
 }
 
 /**

--- a/index.html
+++ b/index.html
@@ -417,10 +417,10 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     // --- Lógica de Chat ---
-    function addMessage(text, sender) {
+    function addMessage(text, sender, messageId = null) {
         const messageContainer = document.createElement('div');
         messageContainer.className = `flex message-bubble ${sender === 'user' ? 'justify-end' : 'justify-start'}`;
-        let bubbleClasses = 'max-w-md lg:max-w-xl rounded-2xl px-4 py-2.5 text-sm shadow-md ';
+        let bubbleClasses = 'relative group max-w-md lg:max-w-xl rounded-2xl px-4 py-2.5 text-sm shadow-md ';
         let bubbleContent = `<p>${text.replace(/\n/g, '<br>')}</p>`;
 
         if (sender === 'user') {
@@ -431,7 +431,28 @@ document.addEventListener('DOMContentLoaded', () => {
             bubbleClasses += 'bg-slate-700/50 border border-slate-600/50 text-slate-400 w-full';
             bubbleContent = `<div class="flex items-center gap-2"><span class="material-symbols-outlined text-emerald-500 text-base">auto_awesome</span><p class="font-mono text-xs">${text}</p></div>`;
         }
-        messageContainer.innerHTML = `<div class="${bubbleClasses}">${bubbleContent}</div>`;
+        messageContainer.innerHTML = `<div class="${bubbleClasses}">${bubbleContent}
+            <div class="absolute top-0 right-0 flex gap-1 p-1 opacity-0 group-hover:opacity-100">
+                <span class="material-symbols-outlined cursor-pointer text-xs action-approve" title="Marcar como aprobado">check</span>
+                <span class="material-symbols-outlined cursor-pointer text-xs action-view" title="Marcar como visto">visibility</span>
+                <span class="material-symbols-outlined cursor-pointer text-xs action-idea" title="Destacar mensaje">lightbulb</span>
+                <span class="material-symbols-outlined cursor-pointer text-xs action-pin" title="Fijar mensaje">push_pin</span>
+            </div>
+        </div>`;
+        const bubble = messageContainer.firstElementChild;
+        if (messageId) bubble.dataset.msgId = messageId;
+        bubble.querySelector('.action-approve').onclick = () => {
+            if (bubble.dataset.msgId) google.script.run.marcarMensajeAprobado(bubble.dataset.msgId);
+        };
+        bubble.querySelector('.action-view').onclick = () => {
+            if (bubble.dataset.msgId) google.script.run.marcarMensajeVisto(bubble.dataset.msgId);
+        };
+        bubble.querySelector('.action-idea').onclick = () => {
+            if (bubble.dataset.msgId) google.script.run.marcarMensajeDestacado(bubble.dataset.msgId);
+        };
+        bubble.querySelector('.action-pin').onclick = () => {
+            if (bubble.dataset.msgId) google.script.run.fijarMensaje(bubble.dataset.msgId);
+        };
         chatWindow.appendChild(messageContainer);
         chatWindow.scrollTop = chatWindow.scrollHeight;
     }


### PR DESCRIPTION
## Resumen
- incluir campos de estado en el registro de mensajes
- crear funciones para aprobar, marcar visto, destacar y fijar mensajes
- mostrar iconos de acción en las burbujas del chat
- documentar las nuevas acciones rápidas

## Pruebas
- `echo "Sin pruebas automáticas"`

------
https://chatgpt.com/codex/tasks/task_e_688053e37b8c832d93558c2a20df82ba