### PR TITLE
Agregar creación de tareas desde mensajes

### DIFF
--- a/Toolbox.gs
+++ b/Toolbox.gs
@@ -1035,6 +1035,21 @@ function fijarMensaje(messageId) {
 }
 
 /**
+ * Marca que de este mensaje se creó una tarea.
+ * @param {string} messageId - ID del mensaje origen.
+ * @returns {string} Confirmación.
+ */
+function marcarMensajeConTarea(messageId) {
+  const ok = updateRowInSheet(SHEET_NAMES.MENSAJES, 'ID_Mensaje', messageId, {
+    Estado: 'Con Tarea'
+  });
+  if (!ok) {
+    throw new Error('No se encontró el mensaje.');
+  }
+  return 'Mensaje marcado con tarea.';
+}
+
+/**
  * Obtiene el ranking de usuarios ordenado por puntaje.
  * @returns {Array<object>} Lista de usuarios con puntos e insignias.
  */

--- a/index.html
+++ b/index.html
@@ -995,7 +995,8 @@ document.addEventListener('DOMContentLoaded', () => {
                                 <div class="py-1" role="none">
                                     ${item.estado === 'Pendiente' ? `<a href="#" class="btn-marcar-revisado block px-4 py-2 text-sm text-slate-300 hover:bg-slate-700" data-item-id="${item.id}">Marcar como Revisado</a>` : ''}
                                     <a href="#" class="btn-add-collab block px-4 py-2 text-sm text-slate-300 hover:bg-slate-700" data-item-id="${item.id}">Agregar Colaborador</a>
-                                <a href="#" class="btn-chat block px-4 py-2 text-sm text-slate-300 hover:bg-slate-700" data-item-id="${item.id}">Ver Comentarios</a>
+                                    <a href="#" class="btn-crear-tarea block px-4 py-2 text-sm text-slate-300 hover:bg-slate-700" data-item-id="${item.id}">Crear Tarea</a>
+                                    <a href="#" class="btn-chat block px-4 py-2 text-sm text-slate-300 hover:bg-slate-700" data-item-id="${item.id}">Ver Comentarios</a>
                                 </div>
                             </div>
                         </div>
@@ -1026,6 +1027,28 @@ document.addEventListener('DOMContentLoaded', () => {
             btn.addEventListener('click', () => {
                 itemColabActual = btn.dataset.itemId;
                 mostrarModalColab();
+            });
+        });
+        container.querySelectorAll('.btn-crear-tarea').forEach(btn => {
+            btn.addEventListener('click', () => {
+                const itemId = btn.dataset.itemId;
+                const item = adminState.items.find(i => i.id === itemId);
+                if (!item) return;
+                showCustomConfirm('¿Crear una tarea con este mensaje?')
+                    .then(conf => {
+                        if (!conf) return;
+                        const titulo = item.asunto || 'Tarea desde mensaje';
+                        const descripcion = item.detalle || '';
+                        const userId = perfilActual.UsuarioID;
+                        const sessionId = sessionStorage.getItem('sessionId');
+                        google.script.run
+                            .withSuccessHandler(msg => {
+                                showCustomAlert(msg, 'success');
+                                google.script.run.marcarMensajeConTarea(itemId);
+                            })
+                            .withFailureHandler(err => showCustomAlert(err.message, 'error'))
+                            .crearTareaPendiente(userId, titulo, descripcion, '', sessionId);
+                    });
             });
         });
         container.querySelectorAll('.btn-chat').forEach(btn => {


### PR DESCRIPTION
## Resumen
- permitir crear una tarea desde la vista de mensajes
- registrar en la hoja que el mensaje generó una tarea

## Pruebas
- `echo "Sin pruebas automáticas"`

------
https://chatgpt.com/codex/tasks/task_e_6880550f2f78832d8d37e620203cd8d2