### PR TITLE
Ajustar extensión al subir imágenes

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -465,10 +465,11 @@ function ejecutarHerramienta(functionName, functionArgs, userId, sessionId) {
  * @returns {string} URL del archivo accesible públicamente.
  */
 function subirImagen(base64, nombre) {
+  const nombreJpg = nombre.replace(/\.\w+$/, '') + '.jpg';
   const blob = Utilities.newBlob(
     Utilities.base64Decode(base64),
     'image/jpeg',
-    nombre
+    nombreJpg
   );
   const folder = DriveApp.getFolderById(FOLDER_IMAGENES);
   const file = folder.createFile(blob);


### PR DESCRIPTION
## Resumen
- fuerza la extensión `.jpg` al subir imágenes para evitar errores

## Pruebas
- `echo "Sin pruebas automáticas"`

------
https://chatgpt.com/codex/tasks/task_e_68807111fb30832db15ca3809c0c1a32