### PR TITLE
Añade análisis de imágenes con OpenAI

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -464,8 +464,8 @@ function ejecutarHerramienta(functionName, functionArgs, userId, sessionId) {
  * Sube una imagen en base64 a Drive y devuelve su URL pública.
  * @param {string} base64 - Cadena de la imagen codificada en base64.
  * @param {string} nombre - Nombre del archivo a guardar.
- * @returns {string} URL del archivo accesible públicamente.
- */
+ * @returns {{url: string, resumen: string}} URL y resumen de la imagen.
+*/
 function subirImagen(base64, nombre) {
   const nombreJpg = nombre.replace(/\.\w+$/, '') + '.jpg';
   const blob = Utilities.newBlob(
@@ -476,7 +476,9 @@ function subirImagen(base64, nombre) {
   const folder = DriveApp.getFolderById(FOLDER_IMAGENES);
   const file = folder.createFile(blob);
   file.setSharing(DriveApp.Access.ANYONE_WITH_LINK, DriveApp.Permission.VIEW);
-  return `https://drive.google.com/uc?export=view&id=${file.getId()}`;
+  const url = `https://drive.google.com/uc?export=view&id=${file.getId()}`;
+  const resumen = analizarImagenOpenAI(base64);
+  return { url: url, resumen: resumen };
 }
 
 // --- LÓGICA DE CALENDARIO DE CONTEO Y REGISTRO DE CONTEOS ---

--- a/OpenAI.gs
+++ b/OpenAI.gs
@@ -156,3 +156,27 @@ function getAIToolByName(name) {
   };
 }
 
+function analizarImagenOpenAI(base64) {
+  try {
+    const requestPayload = {
+      model: 'gpt-4-vision-preview',
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Describí brevemente la imagen enviada.' },
+            { type: 'image_url', image_url: { url: `data:image/jpeg;base64,${base64}` } }
+          ]
+        }
+      ],
+      max_tokens: 100
+    };
+    const respuesta = enviarSolicitudOpenAI(requestPayload, 'vision');
+    if (respuesta.error) return '';
+    return respuesta.choices?.[0]?.message?.content || '';
+  } catch (e) {
+    Logging.logError('OpenAI', 'analizarImagenOpenAI', e.message, e.stack);
+    return '';
+  }
+}
+

--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ Para adjuntar capturas desde la interfaz seguí estos pasos:
 2. Elegí la imagen a cargar y presioná **Enviar imagen**.
 3. La aplicación comprime la imagen, la convierte a base64 y llama a
    `subirImagen`.
-4. La función guarda el archivo en la carpeta de Drive **ImagenesFerrebot** y
-   devuelve un enlace directo para mostrarlo en el chat.
+4. La función guarda el archivo en la carpeta de Drive **ImagenesFerrebot**,
+   analiza el contenido con OpenAI y devuelve un enlace directo junto con un
+   breve resumen.
 
 La carpeta **ImagenesFerrebot** debe existir en tu Google Drive y su ID se
 configura en `FOLDER_IMAGENES`. La cuenta que ejecuta el script necesita permiso

--- a/index.html
+++ b/index.html
@@ -475,7 +475,7 @@ document.addEventListener('DOMContentLoaded', () => {
         chatWindow.scrollTop = chatWindow.scrollHeight;
     }
 
-    function addImageMessage(url, sender = 'user') {
+    function addImageMessage(url, sender = 'user', contexto = '') {
         const container = document.createElement('div');
         container.className = `flex message-bubble ${sender === 'user' ? 'justify-end' : 'justify-start'}`;
         const bubble = document.createElement('div');
@@ -490,9 +490,16 @@ document.addEventListener('DOMContentLoaded', () => {
         img.alt = 'Imagen enviada';
         img.className = 'block w-full h-auto';
         bubble.appendChild(img);
+        if (contexto) {
+            const p = document.createElement('p');
+            p.className = 'p-2 text-white text-sm';
+            p.textContent = contexto;
+            bubble.appendChild(p);
+        }
         container.appendChild(bubble);
         chatWindow.appendChild(container);
         chatWindow.scrollTop = chatWindow.scrollHeight;
+        return bubble;
     }
 
     function showTypingIndicator() {
@@ -854,11 +861,12 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function subirImagenSeleccionada(file) {
+        let imageBubble;
         // Paso 1: leer el archivo para mostrarlo de inmediato.
         const reader = new FileReader();
         reader.onload = e => {
             const localUrl = e.target.result;
-            addImageMessage(localUrl, 'user');
+            imageBubble = addImageMessage(localUrl, 'user');
         };
         reader.readAsDataURL(file);
 
@@ -866,9 +874,18 @@ document.addEventListener('DOMContentLoaded', () => {
         showUploadIndicator();
         compressImage(file, base64 => {
             google.script.run
-                .withSuccessHandler(url => {
+                .withSuccessHandler(data => {
                     hideUploadIndicator();
-                    console.log('Imagen guardada en el servidor en:', url);
+                    console.log('Imagen guardada en el servidor en:', data.url);
+                    if (imageBubble) {
+                        imageBubble.querySelector('img').src = data.url;
+                        if (data.resumen) {
+                            const p = document.createElement('p');
+                            p.className = 'p-2 text-white text-sm';
+                            p.textContent = data.resumen;
+                            imageBubble.appendChild(p);
+                        }
+                    }
                 })
                 .withFailureHandler(err => {
                     hideUploadIndicator();


### PR DESCRIPTION
## Resumen
- se implementa `analizarImagenOpenAI` para utilizar GPT‑4 Vision
- `subirImagen` ahora genera un resumen con OpenAI y lo devuelve junto a la URL
- la interfaz muestra la descripción bajo la imagen enviada
- se documenta el nuevo flujo de análisis en el README

## Pruebas
- `echo "Sin pruebas automáticas"`

------
https://chatgpt.com/codex/tasks/task_e_6880f0ca4534832da596cb746b47003c