### PR TITLE
Mejorar visibilidad del botón Registrar

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,15 +149,15 @@
             <div id="chat-column" class="flex flex-col flex-1 bg-slate-800 overflow-hidden">
                 <main id="chat-window" class="flex-1 p-6 overflow-y-auto space-y-6" aria-live="polite"></main>
                 <div id="suggestions-container" class="px-4 pb-2"></div>
+                <div id="registrar-container" class="px-4 pb-2 hidden flex justify-end">
+                    <button type="button" id="registrar-btn" class="bg-blue-600 hover:bg-blue-700 text-white font-semibold px-4 py-2 rounded-lg">Registrar</button>
+                </div>
                 <footer class="p-4 border-t border-slate-700">
                     <form id="chat-form" class="relative">
                         <input type="text" id="message-input" placeholder="Escribe tu mensaje aquí..." class="w-full bg-slate-700 border border-slate-600 rounded-xl py-3 pl-4 pr-36 text-slate-200 focus:outline-none focus:ring-2 focus:ring-emerald-500 transition-shadow" autocomplete="off">
                         <input type="file" id="image-upload" accept="image/*" class="hidden">
                         <button type="button" id="send-image-button" class="absolute right-20 top-1/2 -translate-y-1/2 bg-emerald-600 hover:bg-emerald-500 w-9 h-9 rounded-lg flex items-center justify-center transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-800 focus-visible:ring-white" aria-label="Enviar Imagen">
                             <span class="material-symbols-outlined text-white">image</span>
-                        </button>
-                        <button type="button" id="registrar-btn" class="absolute right-10 top-1/2 -translate-y-1/2 bg-blue-600 hover:bg-blue-700 w-9 h-9 rounded-lg flex items-center justify-center transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-800 focus-visible:ring-white hidden" aria-label="Registrar">
-                            <span class="material-symbols-outlined text-white">save</span>
                         </button>
                         <button type="submit" id="send-button" class="absolute right-2 top-1/2 -translate-y-1/2 bg-emerald-600 hover:bg-emerald-500 w-9 h-9 rounded-lg flex items-center justify-center transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-800 focus-visible:ring-white" aria-label="Enviar Mensaje">
                             <span class="material-symbols-outlined text-white">send</span>
@@ -247,8 +247,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const sendButton = document.getElementById('send-button');
     const imageUpload = document.getElementById('image-upload');
     const sendImageButton = document.getElementById('send-image-button');
+    const registrarContainer = document.getElementById('registrar-container');
     const registrarBtn = document.getElementById('registrar-btn');
-    registrarBtn.classList.add('hidden');
+    registrarContainer.classList.add('hidden');
     registrarBtn.disabled = true;
 
     // Modales
@@ -659,7 +660,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function iniciarQuickStarter(funcion, pantalla) {
         quickStarterEnUso = { nombreFuncion: funcion, nombrePantalla: pantalla };
-        registrarBtn.classList.add('hidden');
+        registrarContainer.classList.add('hidden');
         registrarBtn.disabled = true;
         addMessage(pantalla, 'user');
         getAIResponse({ texto: pantalla, tool_name: funcion });
@@ -696,7 +697,7 @@ document.addEventListener('DOMContentLoaded', () => {
     function getAIResponse(payload) {
         messageInput.disabled = true;
         sendButton.disabled = true;
-        registrarBtn.classList.add('hidden');
+        registrarContainer.classList.add('hidden');
         registrarBtn.disabled = true;
         showTypingIndicator();
 
@@ -795,7 +796,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     args: functionArgs
                 };
                 addMessage(`Datos listos para "${functionName}". Presioná Registrar para finalizar.`, 'system');
-                registrarBtn.classList.remove('hidden');
+                registrarContainer.classList.remove('hidden');
                 registrarBtn.disabled = false;
                 messageInput.disabled = false;
                 sendButton.disabled = false;
@@ -914,7 +915,7 @@ document.addEventListener('DOMContentLoaded', () => {
     registrarBtn.addEventListener('click', () => {
         if (!herramientaPendiente) return;
         registrarBtn.disabled = true;
-        registrarBtn.classList.add('hidden');
+        registrarContainer.classList.add('hidden');
         const pending = herramientaPendiente;
         herramientaPendiente = null;
         addMessage(`Ejecutando: ${pending.name}...`, 'system');


### PR DESCRIPTION
## Resumen
- mover el botón **Registrar** a un contenedor debajo del chat
- actualizar el script para mostrar u ocultar este contenedor

## Pruebas
- `echo "Sin pruebas automáticas"`

------
https://chatgpt.com/codex/tasks/task_e_6880f5fe7bd8832d942203cd54fbb076