### PR TITLE
Mejora de verificación de entorno en subida de imágenes

### DIFF
--- a/index.html
+++ b/index.html
@@ -891,8 +891,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
         // Paso 2: comprimir y subir en segundo plano.
         showUploadIndicator();
+        if (!window.google?.script?.run) {
+            hideUploadIndicator();
+            showCustomAlert('Esta página debe abrirse desde la app desplegada.', 'error');
+            return;
+        }
         compressImage(file, base64 => {
-            google.script.run
+            window.google.script.run
                 .withSuccessHandler(data => {
                     hideUploadIndicator();
                     console.log('Imagen guardada en el servidor en:', data.url);


### PR DESCRIPTION
## Resumen
- verificar que `window.google.script.run` exista antes de usarlo
- si no está disponible, ocultar el indicador de subida y mostrar una alerta

## Pruebas
- `echo "Sin pruebas automáticas"`

------
https://chatgpt.com/codex/tasks/task_e_688154223360832d8abd6bce93db4bc9