### PR TITLE
Registra errores al fallar la subida de imágenes

### DIFF
--- a/index.html
+++ b/index.html
@@ -909,6 +909,14 @@ document.addEventListener('DOMContentLoaded', () => {
                 .withFailureHandler(err => {
                     hideUploadIndicator();
                     showCustomAlert(`Error al subir la imagen al servidor: ${err.message}`, 'error');
+                    google.script.run.Logging.logError(
+                        'Frontend',
+                        'subirImagenSeleccionada',
+                        err.message,
+                        err && err.stack ? err.stack : '',
+                        file.name,
+                        perfilActual?.UsuarioID || 'N/A'
+                    );
                 })
                 .subirImagen(base64, file.name);
         });


### PR DESCRIPTION
## Resumen
- se agrega el registro de errores en `subirImagenSeleccionada`
- la captura incluye el nombre del archivo y el mensaje de error

## Pruebas
- `echo "Sin pruebas automáticas"`


------
https://chatgpt.com/codex/tasks/task_e_688154271e14832dbe6c0b45d905cdc0