### PR TITLE
Agregar timeout para subida de imagen

### DIFF
--- a/index.html
+++ b/index.html
@@ -892,8 +892,13 @@ document.addEventListener('DOMContentLoaded', () => {
         // Paso 2: comprimir y subir en segundo plano.
         showUploadIndicator();
         compressImage(file, base64 => {
+            const timeoutId = setTimeout(() => {
+                hideUploadIndicator();
+                showCustomAlert('La carga de la imagen excedió el tiempo límite.', 'error');
+            }, 30000);
             google.script.run
                 .withSuccessHandler(data => {
+                    clearTimeout(timeoutId);
                     hideUploadIndicator();
                     console.log('Imagen guardada en el servidor en:', data.url);
                     if (imageBubble) {
@@ -907,6 +912,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     }
                 })
                 .withFailureHandler(err => {
+                    clearTimeout(timeoutId);
                     hideUploadIndicator();
                     showCustomAlert(`Error al subir la imagen al servidor: ${err.message}`, 'error');
                 })


### PR DESCRIPTION
## Resumen
Se añadió un temporizador de 30 segundos en `subirImagenSeleccionada` para cancelar la espera de respuesta al subir la imagen. Si se alcanza el límite, se oculta el indicador y se muestra una alerta de error. Además, el temporizador se limpia tanto en el manejador de éxito como en el de error para evitar cierres incorrectos.

## Pruebas
- `echo "Sin pruebas automáticas"`

------
https://chatgpt.com/codex/tasks/task_e_688154419860832d8ed87f687292ead0