### PR TITLE
Ajuste de URL de descarga para imágenes

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -476,7 +476,7 @@ function subirImagen(base64, nombre) {
   const folder = DriveApp.getFolderById(FOLDER_IMAGENES);
   const file = folder.createFile(blob);
   file.setSharing(DriveApp.Access.ANYONE_WITH_LINK, DriveApp.Permission.VIEW);
-  const url = `https://drive.google.com/uc?export=view&id=${file.getId()}`;
+  const url = file.getDownloadUrl();
   const resumen = analizarImagenOpenAI(base64);
   return { url: url, resumen: resumen };
 }


### PR DESCRIPTION
## Resumen
- usar el enlace de descarga directo al crear archivos de imágenes

## Pruebas
- `echo "Sin pruebas automáticas"`

------
https://chatgpt.com/codex/tasks/task_e_68815aeef8e4832d8953d9bea4be50f4