### PR TITLE
Refactor de quick starters

### DIFF
--- a/Controladores.gs
+++ b/Controladores.gs
@@ -73,16 +73,7 @@ function cargarDatosIniciales(userId, pin) {
     const welcomeMessage = PROMPT_SISTEMA_GENERAL.split('\n').filter(line => line.includes('¡Hola!') || line.includes('•'));
     const anunciosActivos = obtenerAnunciosActivos();
 
-  const quickStarters = HERRAMIENTAS_AI
-      .filter(tool => tool.EsQuickStarter === true)
-      .filter(tool => {
-        const rolesPermitidos = Array.isArray(tool.rolesPermitidos) ? tool.rolesPermitidos : ['Todos'];
-        return rolesPermitidos.includes('Todos') || rolesPermitidos.includes(rolUsuario);
-      })
-      .map(tool => ({
-        NombrePantalla: tool.NombrePantalla,
-        NombreFuncion: tool.NombreFuncion
-      }));
+  const quickStarters = obtenerQuickStarters(rolUsuario);
 
     let responseData = {
       ok: true,
@@ -153,19 +144,7 @@ function reutilizarSesionActiva(userId, sessionId) {
     delete perfil.PIN;
 
     const rolUsuario = perfil.Rol;
-    const quickStarters = HERRAMIENTAS_AI
-      .filter(tool => tool.EsQuickStarter === true)
-      .filter(tool => {
-        const rolesPermitidos = Array.isArray(tool.rolesPermitidos)
-          ? tool.rolesPermitidos
-          : ['Todos'];
-        return rolesPermitidos.includes('Todos') ||
-          rolesPermitidos.includes(rolUsuario);
-      })
-      .map(tool => ({
-        NombrePantalla: tool.NombrePantalla,
-        NombreFuncion: tool.NombreFuncion
-      }));
+    const quickStarters = obtenerQuickStarters(rolUsuario);
 
     updateRowInSheet(SHEET_NAMES.SESIONES, 'SesionID', sessionId, {
       UltimaActividad: getFormattedTimestamp()

--- a/DataHelpers.gs
+++ b/DataHelpers.gs
@@ -39,3 +39,24 @@ function getBranchDetails(branchName) {
   return branchesData.find(b => b.NombreSucursal === branchName) || {};
 }
 
+/**
+ * Obtiene la lista de quick starters permitidos para un rol.
+ * @param {string} rol - Rol del usuario.
+ * @returns {Array<object>} Lista de quick starters disponibles.
+ */
+function obtenerQuickStarters(rol) {
+  return HERRAMIENTAS_AI
+    .filter(tool => tool.EsQuickStarter === true)
+    .filter(tool => {
+      const roles = Array.isArray(tool.rolesPermitidos)
+        ? tool.rolesPermitidos
+        : ['Todos'];
+      return roles.includes('Todos') || roles.includes(rol);
+    })
+    .map(tool => ({
+      NombrePantalla: tool.NombrePantalla,
+      NombreFuncion: tool.NombreFuncion
+    }));
+}
+
+


### PR DESCRIPTION
## Resumen
Se agregó la función `obtenerQuickStarters` en *DataHelpers.gs* para centralizar la lógica de filtrado de acciones rápidas por rol. Ahora `cargarDatosIniciales` y `reutilizarSesionActiva` invocan esta función simplificando el código.

## Pruebas
Se ejecutó:
```
echo "Sin pruebas automáticas"
```


------
https://chatgpt.com/codex/tasks/task_e_68816e3f68a8832da7dea339dd4d6515