### PR TITLE
Incorpora resumen de imagen en el chat

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -504,7 +504,8 @@ function subirImagen(base64, nombre) {
   const file = folder.createFile(blob);
   file.setSharing(DriveApp.Access.ANYONE_WITH_LINK, DriveApp.Permission.VIEW);
   const url = file.getDownloadUrl();
-  return { url: url };
+  const resumen = analizarImagenOpenAI(base64);
+  return { url: url, resumen: resumen };
 }
 
 // --- LÓGICA DE CALENDARIO DE CONTEO Y REGISTRO DE CONTEOS ---

--- a/index.html
+++ b/index.html
@@ -919,6 +919,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     }
                     if (data.resumen) {
                         addMessage(data.resumen, 'ai');
+                        getAIResponse({ texto: data.resumen });
                     }
                 })
                 .withFailureHandler(err => {


### PR DESCRIPTION
## Resumen
- se modificó `subirImagen` para obtener el resumen usando `analizarImagenOpenAI`
- se envía el resumen al historial mediante `getAIResponse`

## Pruebas
- `echo "Sin pruebas automáticas"`

------
https://chatgpt.com/codex/tasks/task_e_68827bf09084832db2c0aec711bdb8f1