### PR TITLE
Modificar gestión de URLs de imágenes

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -505,9 +505,9 @@ function subirImagen(base64, nombre) {
   const folder = DriveApp.getFolderById(FOLDER_IMAGENES);
   const file = folder.createFile(blob);
   file.setSharing(DriveApp.Access.ANYONE_WITH_LINK, DriveApp.Permission.VIEW);
-  const url = file.getDownloadUrl();
+  const url = file.getUrl();
   const resumen = analizarImagenOpenAI(base64);
-  return { url: url, resumen: resumen };
+  return { id: file.getId(), url: url, resumen: resumen };
 }
 
 // --- LÓGICA DE CALENDARIO DE CONTEO Y REGISTRO DE CONTEOS ---

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ Para adjuntar capturas desde la interfaz seguí estos pasos:
 2. Elegí la imagen a cargar y presioná **Enviar imagen**.
 3. La aplicación comprime la imagen, la convierte a base64 y llama a
    `subirImagen`.
-4. La función guarda el archivo en la carpeta de Drive **ImagenesFerrebot**,
-   analiza el contenido con OpenAI y devuelve un enlace directo junto con un
-   breve resumen.
+4. La función guarda el archivo en la carpeta de Drive **ImagenesFerrebot**, 
+   analiza el contenido con OpenAI y devuelve su ID y el enlace de vista junto 
+   con un breve resumen.
 
 La carpeta **ImagenesFerrebot** debe existir en tu Google Drive y su ID se
 configura en `FOLDER_IMAGENES`. La cuenta que ejecuta el script necesita permiso

--- a/Toolbox.gs
+++ b/Toolbox.gs
@@ -507,8 +507,8 @@ function registrarArqueoCaja(userId, saldoSistema, contado, transferencia, tarje
  */
 function registrarRecepcionCompra(userId, fecha, sucursal, proveedor, transporte, total, faltantes, fileUrl, sessionId, imagenes) {
   try {
-    const idMatch = /id=([^&]+)/.exec(fileUrl);
-    const fileId = idMatch ? idMatch[1] : fileUrl;
+    const idMatch = /[-\w]{25,}/.exec(fileUrl);
+    const fileId = idMatch ? idMatch[0] : fileUrl;
     const file = DriveApp.getFileById(fileId);
     const ext = file.getName().split('.').pop();
     const folder = DriveApp.getFolderById(FOLDER_IMAGENES);
@@ -523,7 +523,7 @@ function registrarRecepcionCompra(userId, fecha, sucursal, proveedor, transporte
 
     const asunto = `Factura ${proveedor} ${sucursal}`;
     const detalle = `Fecha: ${fecha}\nProveedor: ${proveedor}\nTransporte: ${transporte}\nTotal: ${total}\nFaltantes: ${faltantes}\nArchivo: ${fileUrl}`;
-    const imagenesTotales = [file.getDownloadUrl()];
+    const imagenesTotales = [file.getUrl()];
     if (Array.isArray(imagenes)) imagenesTotales.push(...imagenes);
     registrarMensaje('Recepción Compra', userId, asunto, detalle, sessionId, 0, imagenesTotales);
     return 'Recepción de compra registrada.';
@@ -544,8 +544,8 @@ function registrarRecepcionCompra(userId, fecha, sucursal, proveedor, transporte
  */
 function registrarTraspaso(userId, fileUrl, comentario, sessionId, imagenes) {
   try {
-    const idMatch = /id=([^&]+)/.exec(fileUrl);
-    const fileId = idMatch ? idMatch[1] : fileUrl;
+    const idMatch = /[-\w]{25,}/.exec(fileUrl);
+    const fileId = idMatch ? idMatch[0] : fileUrl;
     const file = DriveApp.getFileById(fileId);
     const ext = file.getName().split('.').pop();
     const folder = DriveApp.getFolderById(FOLDER_IMAGENES);
@@ -560,7 +560,7 @@ function registrarTraspaso(userId, fileUrl, comentario, sessionId, imagenes) {
 
     const asunto = 'Solicitud de traspaso';
     const detalle = `Comentario: ${comentario}\nArchivo: ${fileUrl}`;
-    const imagenesTotales = [file.getDownloadUrl()];
+    const imagenesTotales = [file.getUrl()];
     if (Array.isArray(imagenes)) imagenesTotales.push(...imagenes);
     registrarMensaje('Traspaso', userId, asunto, detalle, sessionId, 0, imagenesTotales);
     return 'Traspaso registrado correctamente.';

--- a/index.html
+++ b/index.html
@@ -908,7 +908,7 @@ document.addEventListener('DOMContentLoaded', () => {
             window.google.script.run
                 .withSuccessHandler(data => {
                     hideUploadIndicator();
-                    console.log('Imagen guardada en el servidor en:', data.url);
+                    console.log('Imagen guardada en Drive:', data.id, data.url);
                     if (imageBubble) {
                         const img = imageBubble.querySelector('img');
                         img.onerror = () => {


### PR DESCRIPTION
## Resumen
- devolver también la URL estable y el ID al subir imágenes
- almacenar enlaces estables al registrar recepción de compra y traspasos
- ajustar README e index.html con el nuevo comportamiento

## Pruebas
- `echo "Sin pruebas automáticas"`

------
https://chatgpt.com/codex/tasks/task_e_688286131fa8832da74f833ed322904b