### PR TITLE
Mejora extracción de ID de archivo en registros

### DIFF
--- a/Toolbox.gs
+++ b/Toolbox.gs
@@ -507,8 +507,7 @@ function registrarArqueoCaja(userId, saldoSistema, contado, transferencia, tarje
  */
 function registrarRecepcionCompra(userId, fecha, sucursal, proveedor, transporte, total, faltantes, fileUrl, sessionId, imagenes) {
   try {
-    const idMatch = /[-\w]{25,}/.exec(fileUrl);
-    const fileId = idMatch ? idMatch[0] : fileUrl;
+    const fileId = obtenerFileId(fileUrl);
     const file = DriveApp.getFileById(fileId);
     const ext = file.getName().split('.').pop();
     const folder = DriveApp.getFolderById(FOLDER_IMAGENES);
@@ -544,8 +543,7 @@ function registrarRecepcionCompra(userId, fecha, sucursal, proveedor, transporte
  */
 function registrarTraspaso(userId, fileUrl, comentario, sessionId, imagenes) {
   try {
-    const idMatch = /[-\w]{25,}/.exec(fileUrl);
-    const fileId = idMatch ? idMatch[0] : fileUrl;
+    const fileId = obtenerFileId(fileUrl);
     const file = DriveApp.getFileById(fileId);
     const ext = file.getName().split('.').pop();
     const folder = DriveApp.getFolderById(FOLDER_IMAGENES);

--- a/Utils.gs
+++ b/Utils.gs
@@ -55,3 +55,24 @@ function parseSafeDate(dateString) {
   return null;
 }
 
+/**
+ * Obtiene el ID de un archivo de Drive a partir de una URL o del propio ID.
+ * Acepta enlaces con los patrones "id=<ID>" y "/d/<ID>".
+ * @param {string} fileUrl - URL o ID del archivo.
+ * @returns {string} ID del archivo extraído.
+ * @throws {Error} Si no se puede determinar el ID.
+ */
+function obtenerFileId(fileUrl) {
+  if (!fileUrl) {
+    throw new Error('URL o ID de archivo no proporcionado.');
+  }
+  const match = /(?:id=|\/d\/)([-\w]{25,})/.exec(fileUrl);
+  if (match && match[1]) {
+    return match[1];
+  }
+  if (/^[-\w]{25,}$/.test(fileUrl)) {
+    return fileUrl;
+  }
+  throw new Error('No se pudo determinar el ID del archivo.');
+}
+


### PR DESCRIPTION
## Resumen
- agrega la función `obtenerFileId` para extraer el ID de un archivo a partir de una URL
- usa esta función en `registrarRecepcionCompra` y `registrarTraspaso`

## Pruebas
- `echo "Sin pruebas automáticas"`

------
https://chatgpt.com/codex/tasks/task_e_688287e78a88832d8b3493bf2f96831b