### PR TITLE
Eliminar función de modal QuickStarter

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -342,19 +342,6 @@ function abrirModalDeConteo() {
 }
 
 /**
- * Abre el modal para las acciones rápidas con asistencia.
- * @returns {string} El HTML del modal.
- */
-function abrirModalDeQuickStarter() {
-  try {
-    return HtmlService.createHtmlOutputFromFile('quick-modal').getContent();
-  } catch (e) {
-    Logging.logError('Code', 'abrirModalDeQuickStarter', e.message, e.stack);
-    throw new Error('Error al cargar el modal de acciones rápidas: ' + e.message);
-  }
-}
-
-/**
  * Ejecuta una función de herramienta específica y devuelve el resultado.
  * El frontend llamará a esta función cuando la IA solicite usar una herramienta.
  * @param {string} functionName - El nombre de la función a ejecutar (ej. "registrarProblema").


### PR DESCRIPTION
## Resumen
Se eliminó la función `abrirModalDeQuickStarter` del archivo `Code.gs`. Se verificó que ningún archivo HTML ni script del cliente hace referencia a esta función, por lo que su remoción no afecta la funcionalidad existente.

## Pruebas
Se ejecutó el comando indicado por las guías del repositorio:
```
echo "Sin pruebas automáticas"
```


------
https://chatgpt.com/codex/tasks/task_e_68829156b4d0832db6bcd9e7d458e2c4