### PR TITLE
Eliminar constante de inventario

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -287,7 +287,6 @@ function buscarArticulo(query) {
  * @param {string} query - El texto de búsqueda.
  * @returns {Array<object>} Un array de objetos de productos que coinciden.
  */
-const INVENTARIO_COLUMNS = ['Clave','Descripcion','StockSistema','Ubicacion','Precio Costo','Precio Venta','Inversion','Participación','Acumulado','Periodo','Dia','tocaConteoHoy'];
 
 function buscarArticulosAvanzado(query, filter = 'todos') {
   try {


### PR DESCRIPTION
## Resumen
- eliminar la constante `INVENTARIO_COLUMNS` de `Code.gs`
- las funciones de búsqueda siguen utilizando los encabezados dinámicos

## Pruebas
- `echo "Sin pruebas automáticas"`

------
https://chatgpt.com/codex/tasks/task_e_6882915918ec832da91934ce06f047fa