### PR TITLE
Elimina hojas obsoletas de configuración

### DIFF
--- a/Configuracion.gs
+++ b/Configuracion.gs
@@ -33,8 +33,6 @@ const SHEET_NAMES = {
   SUCURSALES: 'Sucursales',
   MOVIMIENTOS_PENDIENTES: 'MovimientosPendientes',
   ANUNCIOS: 'Anuncios',
-  CONFIGURACION_AI: 'ConfiguracionAI',
-  PROMPTS_AI: 'PromptsAI',
   HERRAMIENTAS_AI: 'HerramientasAI',
   ARQUEO_CAJA: 'ArqueoCaja',
   MENSAJE_COLABORADOR: 'MensajeColaborador'


### PR DESCRIPTION
## Resumen
- se eliminaron las constantes `CONFIGURACION_AI` y `PROMPTS_AI` del objeto `SHEET_NAMES`
- se revisó la documentación y no se encontraron referencias a esas hojas

## Pruebas
- `echo "Sin pruebas automáticas"`

------
https://chatgpt.com/codex/tasks/task_e_6882915b1c84832da4247b67c861cb6d