### PR TITLE
Agregar compartición pública en registrarTraspaso

### DIFF
--- a/Toolbox.gs
+++ b/Toolbox.gs
@@ -576,6 +576,8 @@ function registrarTraspaso(userId, fileUrl, comentario, sessionId, imagenes) {
     const folder = DriveApp.getFolderById(FOLDER_IMAGENES);
     const nuevoNombre = `Traspaso_${Date.now()}.${ext}`;
     file.setName(nuevoNombre);
+    // Se comparte el archivo para que cualquiera con el enlace pueda verlo
+    file.setSharing(DriveApp.Access.ANYONE_WITH_LINK, DriveApp.Permission.VIEW);
     const parents = file.getParents();
     let enCarpeta = false;
     while (parents.hasNext()) {


### PR DESCRIPTION
## Resumen
- se comparte el archivo usado en `registrarTraspaso` para que cualquiera con el enlace pueda visualizarlo

## Pruebas
- `echo "Sin pruebas automáticas"`

------
https://chatgpt.com/codex/tasks/task_e_6882b3c29a20832da4e0362efed5eace