### PR TITLE
Añade limpieza de extensión y validación de nombres

### DIFF
--- a/Toolbox.gs
+++ b/Toolbox.gs
@@ -522,17 +522,18 @@ function registrarRecepcionCompra(userId, fecha, sucursal, proveedor, transporte
       : totalNumero.toFixed(2);
     const fileId = obtenerFileId(fileUrl);
     const file = DriveApp.getFileById(fileId);
-    const ext = file.getName().split('.').pop();
+    let ext = file.getName().split('.').pop();
+    ext = limpiarTextoDrive(ext);
     const folder = DriveApp.getFolderById(FOLDER_IMAGENES);
     // Limpieza de datos para evitar caracteres no permitidos en Drive
-    const limpia = t => String(t).replace(/[\/\\:*?"<>|]/g, '-');
-    const fechaLimpia = limpia(fecha);
-    const proveedorLimpio = limpia(proveedor);
-    const sucursalLimpia = limpia(sucursal);
+    const fechaLimpia = limpiarTextoDrive(fecha);
+    const proveedorLimpio = limpiarTextoDrive(proveedor);
+    const sucursalLimpia = limpiarTextoDrive(sucursal);
     let baseNombre = `${fechaLimpia}_Factura_${proveedorLimpio}_${sucursalLimpia}`;
     const maxLong = 255 - ext.length - 1;
     if (baseNombre.length > maxLong) baseNombre = baseNombre.substring(0, maxLong);
-    const nuevoNombre = `${baseNombre}.${ext}`;
+    let nuevoNombre = `${baseNombre}.${ext}`;
+    if (nuevoNombre.length > 255) nuevoNombre = nuevoNombre.substring(0, 255);
     file.setName(nuevoNombre);
     const parents = file.getParents();
     let enCarpeta = false;
@@ -572,9 +573,15 @@ function registrarTraspaso(userId, fileUrl, comentario, sessionId, imagenes) {
   try {
     const fileId = obtenerFileId(fileUrl);
     const file = DriveApp.getFileById(fileId);
-    const ext = file.getName().split('.').pop();
+    let ext = file.getName().split('.').pop();
+    ext = limpiarTextoDrive(ext);
     const folder = DriveApp.getFolderById(FOLDER_IMAGENES);
-    const nuevoNombre = `Traspaso_${Date.now()}.${ext}`;
+    // Limpieza de datos para evitar caracteres no permitidos en Drive
+    let baseNombre = `Traspaso_${Date.now()}`;
+    const maxLong = 255 - ext.length - 1;
+    if (baseNombre.length > maxLong) baseNombre = baseNombre.substring(0, maxLong);
+    let nuevoNombre = `${baseNombre}.${ext}`;
+    if (nuevoNombre.length > 255) nuevoNombre = nuevoNombre.substring(0, 255);
     file.setName(nuevoNombre);
     const parents = file.getParents();
     let enCarpeta = false;

--- a/Utils.gs
+++ b/Utils.gs
@@ -76,3 +76,12 @@ function obtenerFileId(fileUrl) {
   throw new Error('No se pudo determinar el ID del archivo.');
 }
 
+/**
+ * Reemplaza caracteres no permitidos en nombres de archivo de Drive.
+ * @param {string} texto - Texto a limpiar.
+ * @returns {string} Texto sin caracteres inválidos.
+ */
+function limpiarTextoDrive(texto) {
+  return String(texto).replace(/[\/\\:*?"<>|]/g, '-');
+}
+


### PR DESCRIPTION
## Resumen
- crea la función `limpiarTextoDrive` en `Utils.gs`
- usa esta utilidad para limpiar la extensión de archivos al registrar recepción de compra y traspasos
- recorta los nombres si superan 255 caracteres

## Pruebas
- `echo "Sin pruebas automáticas"`

------
https://chatgpt.com/codex/tasks/task_e_6882b3e19ec0832d998d84dec927886b