### PR TITLE
Agregar validación de imágenes en registrarSugerencia

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ aplicación.
 
 Al registrar un problema, sugerencia u otra herramienta que admita archivos,
 las URLs de las capturas se almacenan en la columna **DireccionImagenes** de la
-hoja *Mensajes* separadas por comas.
+hoja *Mensajes* separadas por comas. Podés enviar un arreglo de URLs o una cadena con una sola URL.
 Si subís varias imágenes antes de que la IA llame a una herramienta, todas se
 enviarán juntas como parte del registro.
 
@@ -73,6 +73,7 @@ por ejemplo `marcarMensajeAprobado(id)` o `fijarMensaje(id)`.
 | registrarEgresoCaja     | Registrar un gasto de caja                  | Sí             |
 | arqueoCaja              | Realizar un arqueo de caja                  | Sí             |
 | generarResumenAdmin     | Generar un resumen para administrador       | Sí             |
+Al usar `registrarSugerencia` podés pasar un arreglo de URLs o una sola cadena con la URL de la imagen. Si se envía otro tipo la función responde con un mensaje de error.
 
 Para añadir una nueva herramienta editá la constante `HERRAMIENTAS_AI`
 en `Configuracion.gs`. Definí un objeto con todos los campos mencionados

--- a/Toolbox.gs
+++ b/Toolbox.gs
@@ -90,12 +90,21 @@ function registrarProblema(userId, asunto, detalle, sessionId, imagenes) {
  * @param {string} asunto - Título breve de la sugerencia.
  * @param {string} detalle - Descripción detallada de la sugerencia.
  * @param {string} sessionId - ID de la sesión.
- * @param {Array<string>} [imagenes] - URLs de imágenes adjuntas.
+ * @param {Array<string>|string} [imagenes] - URLs de imágenes adjuntas.
  * @returns {string} Mensaje de confirmación.
  */
 function registrarSugerencia(userId, asunto, detalle, sessionId, imagenes) {
   try {
-    registrarMensaje('Sugerencia', userId, asunto, detalle, sessionId, PUNTOS_SUGERENCIA, imagenes);
+    let urls = [];
+    if (Array.isArray(imagenes)) {
+      urls = imagenes;
+    } else if (typeof imagenes === 'string' && imagenes.trim() !== '') {
+      urls = [imagenes.trim()];
+    } else if (imagenes !== undefined && imagenes !== null) {
+      return 'Error: el parámetro de imágenes debe ser un arreglo o una cadena con la URL.';
+    }
+
+    registrarMensaje('Sugerencia', userId, asunto, detalle, sessionId, PUNTOS_SUGERENCIA, urls);
     return `Listo, registré tu sugerencia: "${asunto}". Gracias.`;
   } catch (e) {
     Logging.logError('Toolbox', 'registrarSugerencia', e.message, e.stack, JSON.stringify({ userId, asunto, detalle, sessionId }));


### PR DESCRIPTION
## Resumen
- aceptar tanto arreglo como cadena en `registrarSugerencia`
- indicar error si el tipo es inválido
- documentar la nueva funcionalidad en el README

## Pruebas
- `echo "Sin pruebas automáticas"`


------
https://chatgpt.com/codex/tasks/task_e_6882d522b2ec832db3194356e12bab6e