### PR TITLE
Agregar validaciones en arqueo de caja

### DIFF
--- a/Configuracion.gs
+++ b/Configuracion.gs
@@ -18,6 +18,7 @@ const OPENAI_API_URL = "https://api.openai.com/v1/chat/completions";
 const ID_HOJA_PUENTE = '1nj2UfUPK5xQg6QI68j9ArLss-ptrlaN3PY8NMOr_Jhg';
 // Carpeta de Drive donde se almacenan las imágenes subidas.
 const FOLDER_IMAGENES = '1bGeMwmGdXOYrnUs0Pr7FcXhtRY9iaY_M';
+const UMBRAL_DIFERENCIA_ARQUEO = 100; // Alerta si la diferencia supera este monto
 
 // ===============================================================
 // ==== CENTRALIZACIÓN DE NOMBRES DE HOJAS ====

--- a/Toolbox.gs
+++ b/Toolbox.gs
@@ -476,12 +476,42 @@ function registrarArqueoCaja(userId, saldoSistema, contado, transferencia, tarje
     const userName = userProfile ? userProfile.Nombre : 'Desconocido';
     const conteoId = generarId('ARQ');
 
-    const montoSistema = parseMontoSeguro(saldoSistema, 'saldoSistema');
-    const montoContado = parseMontoSeguro(contado, 'contado');
-    const montoTransferencia = parseMontoSeguro(transferencia, 'transferencia');
-    const montoTarjeta = parseMontoSeguro(tarjeta, 'tarjeta');
+  const montoSistema = parseMontoSeguro(saldoSistema, 'saldoSistema');
+  const montoContado = parseMontoSeguro(contado, 'contado');
+  const montoTransferencia = parseMontoSeguro(transferencia, 'transferencia');
+  const montoTarjeta = parseMontoSeguro(tarjeta, 'tarjeta');
 
-    diferencia = montoSistema - montoContado - montoTransferencia - montoTarjeta;
+  if (montoSistema < 0) {
+    throw new Error('El campo "saldoSistema" no puede ser negativo.');
+  }
+  if (montoContado < 0) {
+    throw new Error('El campo "contado" no puede ser negativo.');
+  }
+  if (montoTransferencia < 0) {
+    throw new Error('El campo "transferencia" no puede ser negativo.');
+  }
+  if (montoTarjeta < 0) {
+    throw new Error('El campo "tarjeta" no puede ser negativo.');
+  }
+
+  diferencia = montoSistema - montoContado - montoTransferencia - montoTarjeta;
+
+  if (diferencia !== 0 && Math.abs(diferencia) > UMBRAL_DIFERENCIA_ARQUEO) {
+    Logging.logError(
+      'Toolbox',
+      'registrarArqueoCaja',
+      `Diferencia mayor a ${UMBRAL_DIFERENCIA_ARQUEO}: ${diferencia}`,
+      '',
+      JSON.stringify({
+        userId,
+        saldoSistema: montoSistema,
+        contado: montoContado,
+        transferencia: montoTransferencia,
+        tarjeta: montoTarjeta,
+        razon
+      })
+    );
+  }
 
     if (diferencia !== 0 && (!razon || razon.trim() === '')) {
       throw new Error('Se requiere una justificación si la diferencia no es cero.');


### PR DESCRIPTION
## Resumen
- validar que los montos del arqueo no sean negativos
- definir `UMBRAL_DIFERENCIA_ARQUEO` y registrar en el log si la diferencia supera dicho monto

## Pruebas
- `echo "Sin pruebas automáticas"`


------
https://chatgpt.com/codex/tasks/task_e_6887aa69c464832d8fc446671ec2dfb3