### PR TITLE
Reemplazo de clave Firebase en frontend

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -16,6 +16,8 @@
  */
 function doGet() {
   const htmlOutput = HtmlService.createTemplateFromFile('index');
+  htmlOutput.firebaseApiKey = PropertiesService.getScriptProperties()
+    .getProperty('FIREBASE_API_KEY');
   return htmlOutput.evaluate()
     .setTitle('Plataforma Conversacional Interna')
     .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL);

--- a/index.html
+++ b/index.html
@@ -295,8 +295,9 @@ document.addEventListener('DOMContentLoaded', () => {
     let qsHerramientaPendiente = null;
 
     // --- INICIO: CONFIGURACIÓN DE FIREBASE ---
+    // La API key se obtiene de la propiedad de secuencia de comandos
     const firebaseConfig = {
-        apiKey: "AIzaSyCRAoAaoTt1jem-oG1OtYiVAj9M_JwQi8g",
+        apiKey: "<?= firebaseApiKey ?>",
         authDomain: "gestor-tareas-ferreteria.firebaseapp.com",
         databaseURL: "https://gestor-tareas-ferreteria-default-rtdb.firebaseio.com",
         projectId: "gestor-tareas-ferreteria",


### PR DESCRIPTION
## Resumen
- obtener clave de Firebase desde las propiedades del script
- usar esta clave en la configuración de Firebase del frontend

## Pruebas
- `Sin pruebas automáticas`

------
https://chatgpt.com/codex/tasks/task_e_6887b40e1d7c832d936c73a696f98326