### PR TITLE
Mejora detección de proveedor en facturas

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -507,6 +507,25 @@ function subirImagen(base64, nombre, herramientaActiva) {
   let datos = null;
   if (herramientaActiva === 'registrarRecepcionCompra') {
     datos = analizarFacturaOpenAI(base64);
+    if (!datos || !datos.proveedor) {
+      const coincidencia =
+        resumen.match(/factura de\s+([\wÁÉÍÓÚÜÑáéíóúüñ ]+)/i) ||
+        resumen.match(/(Ferre\w+)/i);
+      if (coincidencia) {
+        const nombreProveedor = coincidencia[1]
+          ? coincidencia[1].trim()
+          : coincidencia[0].trim();
+        datos = datos || {};
+        datos.proveedor = nombreProveedor;
+        Logging.logError(
+          'Code',
+          'subirImagen',
+          'Proveedor detectado por respaldo',
+          '',
+          nombreProveedor
+        );
+      }
+    }
   }
   return { id: file.getId(), url: url, resumen: resumen, datos: datos };
 }


### PR DESCRIPTION
## Resumen
- en `subirImagen`, al analizar facturas se verifica si falta el proveedor
- si no se obtuvo, se busca en el resumen con expresiones regulares
- si se encuentra un posible nombre se actualiza `datos` y se registra en `Logging`

## Pruebas
- `echo "Sin pruebas automáticas"`

------
https://chatgpt.com/codex/tasks/task_e_6887c19323d8832da079fac9199fb2a3