### PR TITLE
Corregir enlace de imágenes en subirImagen

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -489,7 +489,8 @@ function subirImagen(base64, nombre, herramientaActiva) {
   const folder = DriveApp.getFolderById(FOLDER_IMAGENES);
   const file = folder.createFile(blob);
   file.setSharing(DriveApp.Access.ANYONE_WITH_LINK, DriveApp.Permission.VIEW);
-  const url = file.getUrl();
+  const url =
+    'https://drive.google.com/uc?export=view&id=' + file.getId();
   let resumen = '';
   switch (herramientaActiva) {
     case 'registrarProblema':


### PR DESCRIPTION
## Resumen
Se modificó la función `subirImagen` para que genere un enlace directo de Google Drive utilizando el ID del archivo. De esta forma las imágenes cargadas permanecen visibles en el chat.

## Pruebas
- `echo "Sin pruebas automáticas"`

------
https://chatgpt.com/codex/tasks/task_e_6887c37409a4832d8cd2e21a10b69a00