### PR TITLE
Actualizar manejo de URL de imágenes en Drive

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -474,10 +474,10 @@ function ejecutarHerramienta(functionName, functionArgs, userId, sessionId) {
 }
 
 /**
- * Sube una imagen en base64 a Drive y devuelve su URL pública.
+ * Sube una imagen en base64 a Drive y devuelve el ID y la URL del archivo.
  * @param {string} base64 - Cadena de la imagen codificada en base64.
  * @param {string} nombre - Nombre del archivo a guardar.
- * @returns {{url: string, resumen: string}} URL y resumen de la imagen.
+ * @returns {{id: string, url: string, resumen: string}} Datos de la imagen.
 */
 function subirImagen(base64, nombre, herramientaActiva) {
   const nombreJpg = nombre.replace(/\.\w+$/, '') + '.jpg';
@@ -489,8 +489,7 @@ function subirImagen(base64, nombre, herramientaActiva) {
   const folder = DriveApp.getFolderById(FOLDER_IMAGENES);
   const file = folder.createFile(blob);
   file.setSharing(DriveApp.Access.ANYONE_WITH_LINK, DriveApp.Permission.VIEW);
-  const url =
-    'https://drive.google.com/uc?export=view&id=' + file.getId();
+  const driveUrl = file.getUrl();
   let resumen = '';
   switch (herramientaActiva) {
     case 'registrarProblema':
@@ -528,7 +527,7 @@ function subirImagen(base64, nombre, herramientaActiva) {
       }
     }
   }
-  return { id: file.getId(), url: url, resumen: resumen, datos: datos };
+  return { id: file.getId(), url: driveUrl, resumen: resumen, datos: datos };
 }
 
 // --- LÓGICA DE CALENDARIO DE CONTEO Y REGISTRO DE CONTEOS ---

--- a/Toolbox.gs
+++ b/Toolbox.gs
@@ -562,7 +562,7 @@ function registrarArqueoCaja(userId, saldoSistema, contado, transferencia, tarje
  * @param {string} transporte - Transporte utilizado.
  * @param {string} total - Monto total de la factura.
  * @param {string} faltantes - Productos faltantes o diferencias.
- * @param {string} fileUrl - Enlace o ID del archivo subido.
+ * @param {string} fileUrl - ID o enlace del archivo subido.
  * @param {string} sessionId - ID de la sesión actual.
  * @param {Array<string>} [imagenes] - Otras imágenes relacionadas.
  * @returns {string} Mensaje de confirmación.
@@ -632,8 +632,9 @@ function registrarRecepcionCompra(userId, fecha, sucursal, proveedor, transporte
     if (!enCarpeta) folder.addFile(file);
 
     const asunto = `Factura ${proveedor} ${sucursal}`;
-    const detalle = `Fecha: ${fecha}\nProveedor: ${proveedor}\nTransporte: ${transporte}\nTotal: ${totalFormateado}\nFaltantes: ${faltantes}\nArchivo: ${fileUrl}`;
-    const imagenesTotales = [file.getUrl()];
+    const finalUrl = file.getUrl();
+    const detalle = `Fecha: ${fecha}\nProveedor: ${proveedor}\nTransporte: ${transporte}\nTotal: ${totalFormateado}\nFaltantes: ${faltantes}\nArchivo: ${finalUrl}`;
+    const imagenesTotales = [finalUrl];
     if (Array.isArray(imagenes)) imagenesTotales.push(...imagenes);
     registrarMensaje('Recepción Compra', userId, asunto, detalle, sessionId, 0, imagenesTotales);
     return 'Recepción de compra registrada.';
@@ -646,7 +647,7 @@ function registrarRecepcionCompra(userId, fecha, sucursal, proveedor, transporte
 /**
  * Registra una solicitud de traspaso enviada por un usuario.
  * @param {string} userId - ID del usuario que envía la captura.
- * @param {string} fileUrl - Enlace o ID de la imagen subida.
+ * @param {string} fileUrl - ID o enlace de la imagen subida.
  * @param {string} comentario - Comentario del usuario.
  * @param {string} sessionId - ID de la sesión.
  * @param {Array<string>} [imagenes] - Otras imágenes relacionadas.
@@ -766,8 +767,9 @@ function registrarTraspaso(userId, fileUrl, comentario, sessionId, imagenes) {
     }
 
     const asunto = 'Solicitud de traspaso';
-    const detalle = `Comentario: ${comentario}\nArchivo: ${fileUrl}`;
-    const imagenesTotales = [file.getUrl()];
+    const finalUrl = file.getUrl();
+    const detalle = `Comentario: ${comentario}\nArchivo: ${finalUrl}`;
+    const imagenesTotales = [finalUrl];
     const extras = parsearImagenes(imagenes);
     imagenesTotales.push(...extras);
     try {

--- a/index.html
+++ b/index.html
@@ -917,7 +917,8 @@ document.addEventListener('DOMContentLoaded', () => {
                                 perfilActual?.UsuarioID || 'N/A'
                             );
                         };
-                        img.src = data.url;
+                        const viewUrl = `https://drive.google.com/uc?export=view&id=${data.id}`;
+                        img.src = viewUrl;
                     }
                     if (data.resumen) {
                         addMessage(data.resumen, 'ai');


### PR DESCRIPTION
## Resumen
- devolver la URL de Drive junto con el ID en `subirImagen`
- registrar recepciones y traspasos usando la URL estable del archivo
- adaptar el frontend para mostrar la imagen a partir del ID

## Pruebas
- `echo "Sin pruebas automáticas"`


------
https://chatgpt.com/codex/tasks/task_e_6887cbc0e228832da9002ccdf6bfe279