### PR TITLE
Maneja rechazos de Firebase al enviar mensajes del chat

### DIFF
--- a/index.html
+++ b/index.html
@@ -1446,11 +1446,9 @@ document.addEventListener('DOMContentLoaded', () => {
             userId: perfilActual.UsuarioID,
             mensaje: texto,
             timestamp: Date.now()
-        }, error => {
-            if (error) {
-                chatInput.value = texto;
-                manejarErrorChatFirebase(error, currentChatItem || 'modal', 'envío');
-            }
+        }).catch(error => {
+            chatInput.value = texto;
+            manejarErrorChatFirebase(error, currentChatItem || 'modal', 'envío');
         });
     }
 
@@ -1569,11 +1567,9 @@ document.addEventListener('DOMContentLoaded', () => {
             userId: perfilActual.UsuarioID,
             mensaje: texto,
             timestamp: Date.now()
-        }, error => {
-            if (error) {
-                inputEl.value = texto;
-                manejarErrorChatFirebase(error, itemId, 'envío');
-            }
+        }).catch(error => {
+            inputEl.value = texto;
+            manejarErrorChatFirebase(error, itemId, 'envío');
         });
     }
 


### PR DESCRIPTION
## Resumen
- captura los rechazos de Firebase al enviar mensajes desde el modal de chat
- evita rechazos sin manejar al enviar mensajes desde las tarjetas de comentarios
- reutiliza el manejador centralizado para notificar la falta de permisos

## Pruebas
- echo "Sin pruebas automáticas"

------
https://chatgpt.com/codex/tasks/task_e_69041b1856d8832d8976ecfdeb5935b4